### PR TITLE
Import graph from local file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
 		<license.copyrightOwners>Board of Regents of the University of
 Wisconsin-Madison and Google, Inc.</license.copyrightOwners>
 
-		<tensorflow.version>1.2.0</tensorflow.version>
+		<tensorflow.version>1.2.1</tensorflow.version>
 		<scijava-common.version>2.65.0</scijava-common.version>
 		<scijava-io-http.version>0.1.0</scijava-io-http.version>
 		<scijava-ui-swing.version>0.9.3</scijava-ui-swing.version>

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
 		<license.copyrightOwners>Board of Regents of the University of
 Wisconsin-Madison and Google, Inc.</license.copyrightOwners>
 
-		<tensorflow.version>1.2.1</tensorflow.version>
+		<tensorflow.version>1.2.0</tensorflow.version>
 		<scijava-common.version>2.65.0</scijava-common.version>
 		<scijava-io-http.version>0.1.0</scijava-io-http.version>
 		<scijava-ui-swing.version>0.9.3</scijava-ui-swing.version>

--- a/src/main/java/net/imagej/tensorflow/DefaultTensorFlowService.java
+++ b/src/main/java/net/imagej/tensorflow/DefaultTensorFlowService.java
@@ -139,6 +139,27 @@ public class DefaultTensorFlowService extends AbstractService implements
 
 		return graph;
 	}
+	
+	@Override
+	public Graph loadGraph(final File graph) throws IOException
+	{
+		final String key = graph.getName();
+
+		// If the graph is already cached in memory, return it.
+		if (graphs.containsKey(key)) return graphs.get(key);
+
+		// Read the serialized graph.
+		final byte[] graphDef = Files.readAllBytes(Paths.get(graph.getAbsolutePath()));
+
+		// Convert to a TensorFlow Graph object.
+		final Graph _graph = new Graph();
+		_graph.importGraphDef(graphDef);
+
+		// Cache the result for performance next time.
+		graphs.put(key, _graph);
+
+		return _graph;
+	}
 
 	@Override
 	public List<String> loadLabels(final Location source, final String modelName,

--- a/src/main/java/net/imagej/tensorflow/DefaultTensorFlowService.java
+++ b/src/main/java/net/imagej/tensorflow/DefaultTensorFlowService.java
@@ -38,6 +38,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.text.DecimalFormat;
 import java.util.Arrays;
 import java.util.HashMap;

--- a/src/main/java/net/imagej/tensorflow/TensorFlowService.java
+++ b/src/main/java/net/imagej/tensorflow/TensorFlowService.java
@@ -51,6 +51,9 @@ public interface TensorFlowService extends ImageJService {
 
 	Graph loadGraph(Location source, String modelName, String graphPath)
 		throws IOException;
+	
+	Graph loadGraph(final File graph)
+		throws IOException;
 
 	List<String> loadLabels(Location source, String modelName, String labelsPath)
 		throws IOException;

--- a/src/main/java/net/imagej/tensorflow/TensorFlowService.java
+++ b/src/main/java/net/imagej/tensorflow/TensorFlowService.java
@@ -30,6 +30,7 @@
 
 package net.imagej.tensorflow;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.List;
 


### PR DESCRIPTION
Hey Curtis,

I couldn't find a way to import a local graph .pb file so I added this function. I think the existing `loadGraph` method expects the graph to be unpacked from a model protocol buffer? If this is redundant, maybe you can point me to a solution using the existing functions?

<del>Also updated the pom to the current tensorflow version.</del>