### PR TITLE
Move example to sandbox

### DIFF
--- a/src/main/java/net/imagej/tensorflow/demo/LabelImage.java
+++ b/src/main/java/net/imagej/tensorflow/demo/LabelImage.java
@@ -68,7 +68,7 @@ import org.tensorflow.Tensor;
  * "www.tensorflow.org/code/tensorflow/java/src/main/java/org/tensorflow/examples/LabelImage.java">
  * Java implementation</a>.
  */
-@Plugin(type = Command.class, menuPath = "TensorFlow Demos>Label Image",
+@Plugin(type = Command.class, menuPath = "Plugins>Sandbox>TensorFlow Demos>Label Image",
 	headless = true)
 public class LabelImage implements Command {
 


### PR DESCRIPTION
Could we move the example to the sandbox? The current version adds another main menu item [hiding the Help menu in legacy mode].