### PR TITLE
Tensorflow generics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,9 @@ Wisconsin-Madison and Google, Inc.</license.copyrightOwners>
 
 		<!-- NB: Deploy releases to the ImageJ Maven repository. -->
 		<releaseProfiles>deploy-to-imagej</releaseProfiles>
+
+		<!-- Override tensorflow version -->
+		<tensorflow.version>1.4.0</tensorflow.version>
 	</properties>
 
 	<repositories>

--- a/src/main/java/net/imagej/tensorflow/GraphBuilder.java
+++ b/src/main/java/net/imagej/tensorflow/GraphBuilder.java
@@ -48,42 +48,76 @@ public class GraphBuilder {
 		this.g = g;
 	}
 
-	public Output div(final Output x, final Output y) {
-		return binaryOp("Div", x, y);
+	public <T, U, V> Output<V> div(final Output<T> x, final Output<U> y) {
+		return binaryOp3("Div", x, y, "Div");
 	}
 
-	public Output sub(final Output x, final Output y) {
-		return binaryOp("Sub", x, y);
+	public <T, U, V> Output<V> div(final Output<T> x, final Output<U> y,
+		final String name)
+	{
+		return binaryOp3("Div", x, y, name);
 	}
 
-	public Output resizeBilinear(final Output images, final Output size) {
-		return binaryOp("ResizeBilinear", images, size);
+	public <T> Output<T> sub(final Output<T> x, final Output<T> y) {
+		return binaryOp("Sub", x, y, "Sub");
 	}
 
-	public Output expandDims(final Output input, final Output dim) {
-		return binaryOp("ExpandDims", input, dim);
+	public <T> Output<T> sub(final Output<T> x, final Output<T> y,
+		final String name)
+	{
+		return binaryOp("Sub", x, y, name);
 	}
 
-	public Output constant(final String name, final Object value) {
-		try (Tensor t = Tensor.create(value)) {
-			return g.opBuilder("Const", name).setAttr("dtype", t.dataType())
-				.setAttr("value", t).build().output(0);
+	public <T, U, V> Output<V> resizeBilinear(final Output<T> images, final Output<U> size) {
+		return binaryOp3("ResizeBilinear", images, size, "ResizeBilinear");
+	}
+
+	public <T, U, V> Output<V> resizeBilinear(final Output<T> images, final Output<U> size,
+		final String name)
+	{
+		return binaryOp3("ResizeBilinear", images, size, name);
+	}
+
+	public <T, U, V> Output<V> expandDims(final Output<T> input, final Output<U> dim) {
+		return binaryOp3("ExpandDims", input, dim, "ExpandDims");
+	}
+
+	public <T, U, V> Output<V> expandDims(final Output<T> input, final Output<U> dim,
+		final String name)
+	{
+		return binaryOp3("ExpandDims", input, dim, name);
+	}
+
+	public Output<?> constant(final String name, final Object value) {
+		try (Tensor<?> t = Tensor.create(value)) {
+			return constant(name, t);
 		}
 	}
 
-	public Output constant(final String name, final float[] value,
+	public Output<Float> constant(final String name, final float[] value,
 		final long... shape)
 	{
-		try (Tensor t = Tensor.create(shape, FloatBuffer.wrap(value))) {
-			return g.opBuilder("Const", name).setAttr("dtype", t.dataType())
-				.setAttr("value", t).build().output(0);
+		try (Tensor<Float> t = Tensor.create(shape, FloatBuffer.wrap(value))) {
+			return constant(name, t);
 		}
 	}
 
-	private Output binaryOp(final String type, final Output in1,
-		final Output in2)
+	public <T> Output<T> constant(final String name, final Tensor<T> value) {
+		return g.opBuilder("Const", name).setAttr("dtype", value.dataType())
+				.setAttr("value", value).build().output(0);
+	}
+
+	private <T> Output<T> binaryOp(final String type, final Output<T> in1,
+		final Output<T> in2, final String name)
 	{
-		return g.opBuilder(type, type).addInput(in1).addInput(in2).build().output(
+		return g.opBuilder(type, name).addInput(in1).addInput(in2).build().output(
+			0);
+	}
+
+	private <T, U, V> Output<V> binaryOp3(final String type, final Output<T> in1,
+		final Output<U> in2, final String name)
+	{
+		return g.opBuilder(type, name).addInput(in1).addInput(in2).build().output(
 			0);
 	}
 }

--- a/src/main/java/net/imagej/tensorflow/Tensors.java
+++ b/src/main/java/net/imagej/tensorflow/Tensors.java
@@ -611,6 +611,211 @@ public final class Tensors {
 		return Tensor.create(shape(image), buffer);
 	}
 
+	/**
+	 * Creates a TensorFlow Tensor containing data from the given byte image.
+	 * <p>
+	 * Note that this will use the backing RAI's primitive array when one is
+	 * available and no dimensions where swapped. Otherwise a copy will be made.
+	 * </p>
+	 * @param image The image which should be put into the Tensor.
+	 * @param dimOrder Defines the mapping of the dimensions between the image
+	 *          and the Tensor where the index corresponds to the dimension
+	 *          in the image and the value corresponds to the dimension in the
+	 *          Tensor. TODO Example?
+	 * @return A Tensor containing the data of the image.
+	 */
+	public static Tensor<UInt8> tensorByte(
+		final RandomAccessibleInterval<ByteType> image, final int[] dimOrder)
+	{
+		return tensorByte(reverse(reorder(image, dimOrder)));
+	}
+
+	/**
+	 * Creates a TensorFlow Tensor containing data from the given double image.
+	 * <p>
+	 * Note that this will use the backing RAI's primitive array when one is
+	 * available and no dimensions where swapped. Otherwise a copy will be made.
+	 * </p>
+	 * @param image The image which should be put into the Tensor.
+	 * @param dimOrder Defines the mapping of the dimensions between the image
+	 *          and the Tensor where the index corresponds to the dimension
+	 *          in the image and the value corresponds to the dimension in the
+	 *          Tensor. TODO Example?
+	 * @return A Tensor containing the data of the image.
+	 */
+	public static Tensor<Double> tensorDouble(
+		final RandomAccessibleInterval<DoubleType> image, final int[] dimOrder)
+	{
+		return tensorDouble(reverse(reorder(image, dimOrder)));
+	}
+
+	/**
+	 * Creates a TensorFlow Tensor containing data from the given float image.
+	 * <p>
+	 * Note that this will use the backing RAI's primitive array when one is
+	 * available and no dimensions where swapped. Otherwise a copy will be made.
+	 * </p>
+	 * @param image The image which should be put into the Tensor.
+	 * @param dimOrder Defines the mapping of the dimensions between the image
+	 *          and the Tensor where the index corresponds to the dimension
+	 *          in the image and the value corresponds to the dimension in the
+	 *          Tensor. TODO Example?
+	 * @return A Tensor containing the data of the image.
+	 */
+	public static Tensor<Float> tensorFloat(
+		final RandomAccessibleInterval<FloatType> image, final int[] dimOrder)
+	{
+		return tensorFloat(reverse(reorder(image, dimOrder)));
+	}
+
+	/**
+	 * Creates a TensorFlow Tensor containing data from the given int image.
+	 * <p>
+	 * Note that this will use the backing RAI's primitive array when one is
+	 * available and no dimensions where swapped. Otherwise a copy will be made.
+	 * </p>
+	 * @param image The image which should be put into the Tensor.
+	 * @param dimOrder Defines the mapping of the dimensions between the image
+	 *          and the Tensor where the index corresponds to the dimension
+	 *          in the image and the value corresponds to the dimension in the
+	 *          Tensor. TODO Example?
+	 * @return A Tensor containing the data of the image.
+	 */
+	public static Tensor<Integer> tensorInt(
+		final RandomAccessibleInterval<IntType> image, final int[] dimOrder)
+	{
+		return tensorInt(reverse(reorder(image, dimOrder)));
+	}
+
+	/**
+	 * Creates a TensorFlow Tensor containing data from the given long image.
+	 * <p>
+	 * Note that this will use the backing RAI's primitive array when one is
+	 * available and no dimensions where swapped. Otherwise a copy will be made.
+	 * </p>
+	 * @param image The image which should be put into the Tensor.
+	 * @param dimOrder Defines the mapping of the dimensions between the image
+	 *          and the Tensor where the index corresponds to the dimension
+	 *          in the image and the value corresponds to the dimension in the
+	 *          Tensor. TODO Example?
+	 * @return A Tensor containing the data of the image.
+	 */
+	public static Tensor<Long> tensorLong(
+		final RandomAccessibleInterval<LongType> image, final int[] dimOrder)
+	{
+		return tensorLong(reverse(reorder(image, dimOrder)));
+	}
+
+	/**
+	 * Creates a TensorFlow Tensor containing data from the given byte image.
+	 * <p>
+	 * Note that this _does_ adjust the dimensions. This means that
+	 * the resulting Tensor will have a shape directly corresponding to the
+	 * dimensions of the image. Make sure the dimensions are as you want
+	 * them in TensorFlow. See {@link #tensorByte(RandomAccessibleInterval)} and
+	 * {@link #tensorByte(RandomAccessibleInterval, int[])} if you want to handle
+	 * dimensions differently.
+	 * </p><p>
+	 * Also note that this will use the backing RAI's primitive array when one is
+	 * available. Otherwise a copy will be made.
+	 * </p>
+	 * @param image The image which should be put into the Tensor.
+	 * @return A Tensor containing the data of the image.
+	 */
+	public static Tensor<UInt8> tensorByteDirect(
+		final RandomAccessibleInterval<ByteType> image)
+	{
+		return tensorByte(reverse(image));
+	}
+
+	/**
+	 * Creates a TensorFlow Tensor containing data from the given double image.
+	 * <p>
+	 * Note that this _does_ adjust the dimensions. This means that
+	 * the resulting Tensor will have a shape directly corresponding to the
+	 * dimensions of the image. Make sure the dimensions are as you want
+	 * them in TensorFlow. See {@link #tensorDouble(RandomAccessibleInterval)} and
+	 * {@link #tensorDouble(RandomAccessibleInterval, int[])} if you want to handle
+	 * dimensions differently.
+	 * </p><p>
+	 * Also note that this will use the backing RAI's primitive array when one is
+	 * available. Otherwise a copy will be made.
+	 * </p>
+	 * @param image The image which should be put into the Tensor.
+	 * @return A Tensor containing the data of the image.
+	 */
+	public static Tensor<Double> tensorDoubleDirect(
+		final RandomAccessibleInterval<DoubleType> image)
+	{
+		return tensorDouble(reverse(image));
+	}
+
+	/**
+	 * Creates a TensorFlow Tensor containing data from the given float image.
+	 * <p>
+	 * Note that this _does_ adjust the dimensions. This means that
+	 * the resulting Tensor will have a shape directly corresponding to the
+	 * dimensions of the image. Make sure the dimensions are as you want
+	 * them in TensorFlow. See {@link #tensorFloat(RandomAccessibleInterval)} and
+	 * {@link #tensorFloat(RandomAccessibleInterval, int[])} if you want to handle
+	 * dimensions differently.
+	 * </p><p>
+	 * Also note that this will use the backing RAI's primitive array when one is
+	 * available. Otherwise a copy will be made.
+	 * </p>
+	 * @param image The image which should be put into the Tensor.
+	 * @return A Tensor containing the data of the image.
+	 */
+	public static Tensor<Float> tensorFloatDirect(
+		final RandomAccessibleInterval<FloatType> image)
+	{
+		return tensorFloat(reverse(image));
+	}
+
+	/**
+	 * Creates a TensorFlow Tensor containing data from the given int image.
+	 * <p>
+	 * Note that this _does_ adjust the dimensions. This means that
+	 * the resulting Tensor will have a shape directly corresponding to the
+	 * dimensions of the image. Make sure the dimensions are as you want
+	 * them in TensorFlow. See {@link #tensorInt(RandomAccessibleInterval)} and
+	 * {@link #tensorInt(RandomAccessibleInterval, int[])} if you want to handle
+	 * dimensions differently.
+	 * </p><p>
+	 * Also note that this will use the backing RAI's primitive array when one is
+	 * available. Otherwise a copy will be made.
+	 * </p>
+	 * @param image The image which should be put into the Tensor.
+	 * @return A Tensor containing the data of the image.
+	 */
+	public static Tensor<Integer> tensorIntDirect(
+		final RandomAccessibleInterval<IntType> image)
+	{
+		return tensorInt(reverse(image));
+	}
+
+	/**
+	 * Creates a TensorFlow Tensor containing data from the given long image.
+	 * <p>
+	 * Note that this _does_ adjust the dimensions. This means that
+	 * the resulting Tensor will have a shape directly corresponding to the
+	 * dimensions of the image. Make sure the dimensions are as you want
+	 * them in TensorFlow. See {@link #tensorLong(RandomAccessibleInterval)} and
+	 * {@link #tensorLong(RandomAccessibleInterval, int[])} if you want to handle
+	 * dimensions differently.
+	 * </p><p>
+	 * Also note that this will use the backing RAI's primitive array when one is
+	 * available. Otherwise a copy will be made.
+	 * </p>
+	 * @param image The image which should be put into the Tensor.
+	 * @return A Tensor containing the data of the image.
+	 */
+	public static Tensor<Long> tensorLongDirect(
+		final RandomAccessibleInterval<LongType> image)
+	{
+		return tensorLong(reverse(image));
+	}
+
 	// --------- DIMENSIONAL HELPER METHODS ---------
 
 	/**

--- a/src/main/java/net/imagej/tensorflow/Tensors.java
+++ b/src/main/java/net/imagej/tensorflow/Tensors.java
@@ -40,6 +40,7 @@ import java.util.stream.IntStream;
 
 import org.tensorflow.DataType;
 import org.tensorflow.Tensor;
+import org.tensorflow.types.UInt8;
 
 import net.imglib2.Cursor;
 import net.imglib2.Dimensions;
@@ -523,7 +524,7 @@ public final class Tensors {
 	{
 		final byte[] value = byteArray(image);
 		ByteBuffer buffer = ByteBuffer.wrap(value);
-		return Tensor.create(DataType.UINT8, shape(image), buffer);
+		return Tensor.create(UInt8.class, shape(image), buffer);
 	}
 
 	/**

--- a/src/main/java/net/imagej/tensorflow/Tensors.java
+++ b/src/main/java/net/imagej/tensorflow/Tensors.java
@@ -126,7 +126,7 @@ public final class Tensors {
 	 * @param image The TensorFlow Tensor.
 	 * @return An image containing the data of the Tensor.
 	 */
-	public static Img<ByteType> imgByte(final Tensor image) {
+	public static Img<ByteType> imgByte(final Tensor<UInt8> image) {
 		final byte[] out = new byte[image.numElements()];
 		image.writeTo(ByteBuffer.wrap(out));
 		return ArrayImgs.bytes(out, shape(image));
@@ -146,7 +146,7 @@ public final class Tensors {
 	 * @return An image containing the data of the Tensor.
 	 * @throws IllegalArgumentException if Tensor data type is not double.
 	 */
-	public static Img<DoubleType> imgDouble(final Tensor image) {
+	public static Img<DoubleType> imgDouble(final Tensor<Double> image) {
 		final double[] out = new double[image.numElements()];
 		image.writeTo(DoubleBuffer.wrap(out));
 		return ArrayImgs.doubles(out, shape(image));
@@ -166,7 +166,7 @@ public final class Tensors {
 	 * @return An image containing the data of the Tensor.
 	 * @throws IllegalArgumentException if Tensor data type is not float.
 	 */
-	public static Img<FloatType> imgFloat(final Tensor image) {
+	public static Img<FloatType> imgFloat(final Tensor<Float> image) {
 		final float[] out = new float[image.numElements()];
 		image.writeTo(FloatBuffer.wrap(out));
 		return ArrayImgs.floats(out, shape(image));
@@ -186,7 +186,7 @@ public final class Tensors {
 	 * @return An image containing the data of the Tensor.
 	 * @throws IllegalArgumentException if Tensor data type is not int.
 	 */
-	public static Img<IntType> imgInt(final Tensor image) {
+	public static Img<IntType> imgInt(final Tensor<Integer> image) {
 		final int[] out = new int[image.numElements()];
 		image.writeTo(IntBuffer.wrap(out));
 		return ArrayImgs.ints(out, shape(image));
@@ -206,7 +206,7 @@ public final class Tensors {
 	 * @return An image containing the data of the Tensor.
 	 * @throws IllegalArgumentException if Tensor data type is not long.
 	 */
-	public static Img<LongType> imgLong(final Tensor image) {
+	public static Img<LongType> imgLong(final Tensor<Long> image) {
 		final long[] out = new long[image.numElements()];
 		image.writeTo(LongBuffer.wrap(out));
 		return ArrayImgs.longs(out, shape(image));
@@ -226,7 +226,7 @@ public final class Tensors {
 	 *          Tensor. TODO Example?
 	 * @return An image containing the data of the Tensor.
 	 */
-	public static Img<ByteType> imgByte(final Tensor image, int[] dimOrder) {
+	public static Img<ByteType> imgByte(final Tensor<UInt8> image, int[] dimOrder) {
 		return reverseReorder(reverse(imgByte(image)), dimOrder);
 	}
 
@@ -242,7 +242,7 @@ public final class Tensors {
 	 * @return An image containing the data of the Tensor.
 	 * @throws IllegalArgumentException if Tensor data type is not double.
 	 */
-	public static Img<DoubleType> imgDouble(final Tensor image, int[] dimOrder) {
+	public static Img<DoubleType> imgDouble(final Tensor<Double> image, int[] dimOrder) {
 		return reverseReorder(reverse(imgDouble(image)), dimOrder);
 	}
 
@@ -258,7 +258,7 @@ public final class Tensors {
 	 * @return An image containing the data of the Tensor.
 	 * @throws IllegalArgumentException if Tensor data type is not float.
 	 */
-	public static Img<FloatType> imgFloat(final Tensor image, int[] dimOrder) {
+	public static Img<FloatType> imgFloat(final Tensor<Float> image, int[] dimOrder) {
 		return reverseReorder(reverse(imgFloat(image)), dimOrder);
 	}
 
@@ -274,7 +274,7 @@ public final class Tensors {
 	 * @return An image containing the data of the Tensor.
 	 * @throws IllegalArgumentException if Tensor data type is not int.
 	 */
-	public static Img<IntType> imgInt(final Tensor image, int[] dimOrder) {
+	public static Img<IntType> imgInt(final Tensor<Integer> image, int[] dimOrder) {
 		return reverseReorder(reverse(imgInt(image)), dimOrder);
 	}
 
@@ -290,7 +290,7 @@ public final class Tensors {
 	 * @return An image containing the data of the Tensor.
 	 * @throws IllegalArgumentException if Tensor data type is not long.
 	 */
-	public static Img<LongType> imgLong(final Tensor image, int[] dimOrder) {
+	public static Img<LongType> imgLong(final Tensor<Long> image, int[] dimOrder) {
 		return reverseReorder(reverse(imgLong(image)), dimOrder);
 	}
 
@@ -310,7 +310,7 @@ public final class Tensors {
 	 * @param image The TensorFlow Tensor.
 	 * @return An image containing the data of the Tensor.
 	 */
-	public static Img<ByteType> imgByteDirect(final Tensor image) {
+	public static Img<ByteType> imgByteDirect(final Tensor<UInt8> image) {
 		return reverse(imgByte(image));
 	}
 
@@ -328,7 +328,7 @@ public final class Tensors {
 	 * @return An image containing the data of the Tensor.
 	 * @throws IllegalArgumentException if Tensor data type is not double.
 	 */
-	public static Img<DoubleType> imgDoubleDirect(final Tensor image) {
+	public static Img<DoubleType> imgDoubleDirect(final Tensor<Double> image) {
 		return reverse(imgDouble(image));
 	}
 
@@ -346,7 +346,7 @@ public final class Tensors {
 	 * @return An image containing the data of the Tensor.
 	 * @throws IllegalArgumentException if Tensor data type is not float.
 	 */
-	public static Img<FloatType> imgFloatDirect(final Tensor image) {
+	public static Img<FloatType> imgFloatDirect(final Tensor<Float> image) {
 		return reverse(imgFloat(image));
 	}
 
@@ -364,7 +364,7 @@ public final class Tensors {
 	 * @return An image containing the data of the Tensor.
 	 * @throws IllegalArgumentException if Tensor data type is not int.
 	 */
-	public static Img<IntType> imgIntDirect(final Tensor image) {
+	public static Img<IntType> imgIntDirect(final Tensor<Integer> image) {
 		return reverse(imgInt(image));
 	}
 
@@ -382,7 +382,7 @@ public final class Tensors {
 	 * @return An image containing the data of the Tensor.
 	 * @throws IllegalArgumentException if Tensor data type is not long.
 	 */
-	public static Img<LongType> imgLongDirect(final Tensor image) {
+	public static Img<LongType> imgLongDirect(final Tensor<Long> image) {
 		return reverse(imgLong(image));
 	}
 
@@ -408,7 +408,7 @@ public final class Tensors {
 	 *          Supported types are {@link ByteType}, {@link DoubleType},
 	 *          {@link FloatType}, {@link IntType} and {@link LongType}.
 	 */
-	public static <T extends RealType<T>> Tensor tensor(
+	public static <T extends RealType<T>> Tensor<?> tensor(
 		final RandomAccessibleInterval<T> image)
 	{
 		// NB: In the functions called we use reversed dimensions because
@@ -471,7 +471,7 @@ public final class Tensors {
 	 *          Supported types are {@link ByteType}, {@link DoubleType},
 	 *          {@link FloatType}, {@link IntType} and {@link LongType}.
 	 */
-	public static <T extends RealType<T>> Tensor tensor(
+	public static <T extends RealType<T>> Tensor<?> tensor(
 		final RandomAccessibleInterval<T> image, int[] dimOrder)
 	{
 		// TODO Are 2 calls bad? More views are created but they should be smart
@@ -498,7 +498,7 @@ public final class Tensors {
 	 *          Supported types are {@link ByteType}, {@link DoubleType},
 	 *          {@link FloatType}, {@link IntType} and {@link LongType}.
 	 */
-	public static <T extends RealType<T>> Tensor tensorDirect(
+	public static <T extends RealType<T>> Tensor<?> tensorDirect(
 		final RandomAccessibleInterval<T> image)
 	{
 		return tensor(reverse(image));
@@ -519,7 +519,7 @@ public final class Tensors {
 	 * @param image The image which should be put into the Tensor.
 	 * @return A Tensor containing the data of the image.
 	 */
-	public static Tensor tensorByte(
+	public static Tensor<UInt8> tensorByte(
 		final RandomAccessibleInterval<ByteType> image)
 	{
 		final byte[] value = byteArray(image);
@@ -540,7 +540,7 @@ public final class Tensors {
 	 * @param image The image which should be put into the Tensor.
 	 * @return A Tensor containing the data of the image.
 	 */
-	public static Tensor tensorDouble(
+	public static Tensor<Double> tensorDouble(
 		final RandomAccessibleInterval<DoubleType> image)
 	{
 		final double[] value = doubleArray(image);
@@ -561,7 +561,7 @@ public final class Tensors {
 	 * @param image The image which should be put into the Tensor.
 	 * @return A Tensor containing the data of the image.
 	 */
-	public static Tensor tensorFloat(
+	public static Tensor<Float> tensorFloat(
 		final RandomAccessibleInterval<FloatType> image)
 	{
 		final float[] value = floatArray(image);
@@ -582,7 +582,7 @@ public final class Tensors {
 	 * @param image The image which should be put into the Tensor.
 	 * @return A Tensor containing the data of the image.
 	 */
-	public static Tensor tensorInt(
+	public static Tensor<Integer> tensorInt(
 		final RandomAccessibleInterval<IntType> image)
 	{
 		final int[] value = intArray(image);
@@ -603,7 +603,7 @@ public final class Tensors {
 	 * @param image The image which should be put into the Tensor.
 	 * @return A Tensor containing the data of the image.
 	 */
-	public static Tensor tensorLong(
+	public static Tensor<Long> tensorLong(
 		final RandomAccessibleInterval<LongType> image)
 	{
 		final long[] value = longArray(image);
@@ -635,7 +635,7 @@ public final class Tensors {
 	 * @param tensor The tensor whose dimension length are desired.
 	 * @return The imglib dimension length.
 	 */
-	private static long[] shape(final Tensor tensor) {
+	private static long[] shape(final Tensor<?> tensor) {
 		return shape(new FinalDimensions(tensor.shape()));
 	}
 

--- a/src/test/java/net/imagej/tensorflow/TensorsTest.java
+++ b/src/test/java/net/imagej/tensorflow/TensorsTest.java
@@ -47,6 +47,7 @@ import java.util.stream.IntStream;
 import org.junit.Test;
 import org.tensorflow.DataType;
 import org.tensorflow.Tensor;
+import org.tensorflow.types.UInt8;
 
 import net.imglib2.Point;
 import net.imglib2.RandomAccess;
@@ -79,7 +80,7 @@ public class TensorsTest {
 		// Create Tensors of different type and convert them to images
 		ByteBuffer dataByte = ByteBuffer.allocateDirect(size);
 		execForPointsWithBufferIndex(shape, mapping, points, (i, v) -> dataByte.put(i, (byte) (int) v));
-		Tensor tensorByte = Tensor.create(DataType.UINT8, shape, dataByte);
+		Tensor tensorByte = Tensor.create(UInt8.class, shape, dataByte);
 		Img<ByteType> imgByte = Tensors.imgByte(tensorByte);
 
 		DoubleBuffer dataDouble = DoubleBuffer.allocate(size);
@@ -124,7 +125,7 @@ public class TensorsTest {
 		// Create Tensors of different type and convert them to images
 		ByteBuffer dataByte = ByteBuffer.allocateDirect(size);
 		execForPointsWithBufferIndex(shape, mapping, points, (i, v) -> dataByte.put(i, (byte) (int) v));
-		Tensor tensorByte = Tensor.create(DataType.UINT8, shape, dataByte);
+		Tensor tensorByte = Tensor.create(UInt8.class, shape, dataByte);
 		Img<ByteType> imgByte = Tensors.imgByteDirect(tensorByte);
 
 		DoubleBuffer dataDouble = DoubleBuffer.allocate(size);
@@ -170,7 +171,7 @@ public class TensorsTest {
 		// Create Tensors of different type and convert them to images
 		ByteBuffer dataByte = ByteBuffer.allocateDirect(size);
 		execForPointsWithBufferIndex(shape, mapping, points, (i, v) -> dataByte.put(i, (byte) (int) v));
-		Tensor tensorByte = Tensor.create(DataType.UINT8, shape, dataByte);
+		Tensor tensorByte = Tensor.create(UInt8.class, shape, dataByte);
 		Img<ByteType> imgByte = Tensors.imgByte(tensorByte, mapping);
 
 		DoubleBuffer dataDouble = DoubleBuffer.allocate(size);

--- a/src/test/java/net/imagej/tensorflow/TensorsTest.java
+++ b/src/test/java/net/imagej/tensorflow/TensorsTest.java
@@ -49,6 +49,8 @@ import org.tensorflow.DataType;
 import org.tensorflow.Tensor;
 import org.tensorflow.types.UInt8;
 
+import com.google.common.base.Function;
+
 import net.imglib2.Point;
 import net.imglib2.RandomAccess;
 import net.imglib2.img.Img;
@@ -222,23 +224,23 @@ public class TensorsTest {
 		final int n = dims.length;
 
 		// ByteType
-		testImg2TensorReverseForType(new ArrayImgFactory<ByteType>().create(dims, new ByteType()), n, shape,
+		testImg2TensorReverse(new ArrayImgFactory<ByteType>().create(dims, new ByteType()), n, shape,
 				DataType.UINT8);
 
 		// DoubleType
-		testImg2TensorReverseForType(new ArrayImgFactory<DoubleType>().create(dims, new DoubleType()), n, shape,
+		testImg2TensorReverse(new ArrayImgFactory<DoubleType>().create(dims, new DoubleType()), n, shape,
 				DataType.DOUBLE);
 
 		// FloatType
-		testImg2TensorReverseForType(new ArrayImgFactory<FloatType>().create(dims, new FloatType()), n, shape,
+		testImg2TensorReverse(new ArrayImgFactory<FloatType>().create(dims, new FloatType()), n, shape,
 				DataType.FLOAT);
 
 		// IntType
-		testImg2TensorReverseForType(new ArrayImgFactory<IntType>().create(dims, new IntType()), n, shape,
+		testImg2TensorReverse(new ArrayImgFactory<IntType>().create(dims, new IntType()), n, shape,
 				DataType.INT32);
 
 		// LongType
-		testImg2TensorReverseForType(new ArrayImgFactory<LongType>().create(dims, new LongType()), n, shape,
+		testImg2TensorReverse(new ArrayImgFactory<LongType>().create(dims, new LongType()), n, shape,
 				DataType.INT64);
 	}
 
@@ -251,23 +253,23 @@ public class TensorsTest {
 		final int n = dims.length;
 
 		// ByteType
-		testImg2TensorDirectForType(new ArrayImgFactory<ByteType>().create(dims, new ByteType()), n, dims,
+		testImg2TensorDirect(new ArrayImgFactory<ByteType>().create(dims, new ByteType()), n, dims,
 				DataType.UINT8);
 
 		// DoubleType
-		testImg2TensorDirectForType(new ArrayImgFactory<DoubleType>().create(dims, new DoubleType()), n, dims,
+		testImg2TensorDirect(new ArrayImgFactory<DoubleType>().create(dims, new DoubleType()), n, dims,
 				DataType.DOUBLE);
 
 		// FloatType
-		testImg2TensorDirectForType(new ArrayImgFactory<FloatType>().create(dims, new FloatType()), n, dims,
+		testImg2TensorDirect(new ArrayImgFactory<FloatType>().create(dims, new FloatType()), n, dims,
 				DataType.FLOAT);
 
 		// IntType
-		testImg2TensorDirectForType(new ArrayImgFactory<IntType>().create(dims, new IntType()), n, dims,
+		testImg2TensorDirect(new ArrayImgFactory<IntType>().create(dims, new IntType()), n, dims,
 				DataType.INT32);
 
 		// LongType
-		testImg2TensorDirectForType(new ArrayImgFactory<LongType>().create(dims, new LongType()), n, dims,
+		testImg2TensorDirect(new ArrayImgFactory<LongType>().create(dims, new LongType()), n, dims,
 				DataType.INT64);
 	}
 
@@ -282,28 +284,118 @@ public class TensorsTest {
 		final int n = dims.length;
 
 		// ByteType
-		testImg2TensorMappingForType(new ArrayImgFactory<ByteType>().create(dims, new ByteType()), mapping, n, shape,
+		testImg2TensorMapping(new ArrayImgFactory<ByteType>().create(dims, new ByteType()), mapping, n, shape,
 				DataType.UINT8);
 
 		// DoubleType
-		testImg2TensorMappingForType(new ArrayImgFactory<DoubleType>().create(dims, new DoubleType()), mapping, n,
+		testImg2TensorMapping(new ArrayImgFactory<DoubleType>().create(dims, new DoubleType()), mapping, n,
 				shape, DataType.DOUBLE);
 
 		// FloatType
-		testImg2TensorMappingForType(new ArrayImgFactory<FloatType>().create(dims, new FloatType()), mapping, n, shape,
+		testImg2TensorMapping(new ArrayImgFactory<FloatType>().create(dims, new FloatType()), mapping, n, shape,
 				DataType.FLOAT);
 
 		// IntType
-		testImg2TensorMappingForType(new ArrayImgFactory<IntType>().create(dims, new IntType()), mapping, n, shape,
+		testImg2TensorMapping(new ArrayImgFactory<IntType>().create(dims, new IntType()), mapping, n, shape,
 				DataType.INT32);
 
 		// LongType
-		testImg2TensorMappingForType(new ArrayImgFactory<LongType>().create(dims, new LongType()), mapping, n, shape,
+		testImg2TensorMapping(new ArrayImgFactory<LongType>().create(dims, new LongType()), mapping, n, shape,
 				DataType.INT64);
 	}
 
+	/** Tests the tensor<Type>(RAI) function */
+	@Test
+	public void testImgToTensorReverseTyped() {
+		assertEquals(1, 1);
+
+		final long[] dims = new long[] { 20, 10, 3 };
+		final long[] shape = new long[] { 3, 10, 20 };
+		final int n = dims.length;
+
+		// ByteType
+		testImg2TensorReverseTyped(new ArrayImgFactory<ByteType>().create(dims, new ByteType()), n, shape,
+				UInt8.class, (i) -> Tensors.tensorByte(i));
+
+		// DoubleType
+		testImg2TensorReverseTyped(new ArrayImgFactory<DoubleType>().create(dims, new DoubleType()), n, shape,
+				Double.class, (i) -> Tensors.tensorDouble(i));
+
+		// FloatType
+		testImg2TensorReverseTyped(new ArrayImgFactory<FloatType>().create(dims, new FloatType()), n, shape,
+				Float.class, (i) -> Tensors.tensorFloat(i));
+
+		// IntType
+		testImg2TensorReverseTyped(new ArrayImgFactory<IntType>().create(dims, new IntType()), n, shape,
+				Integer.class, (i) -> Tensors.tensorInt(i));
+
+		// LongType
+		testImg2TensorReverseTyped(new ArrayImgFactory<LongType>().create(dims, new LongType()), n, shape,
+				Long.class, (i) -> Tensors.tensorLong(i));
+	}
+
+	/** Tests the tensor<Type>Direct(RAI) function */
+	@Test
+	public void testImgToTensorDirectTyped() {
+		assertEquals(1, 1);
+
+		final long[] dims = new long[] { 20, 10, 3 };
+		final int n = dims.length;
+
+		// ByteType
+		testImg2TensorDirectTyped(new ArrayImgFactory<ByteType>().create(dims, new ByteType()), n, dims,
+				UInt8.class, (i) -> Tensors.tensorByteDirect(i));
+
+		// DoubleType
+		testImg2TensorDirectTyped(new ArrayImgFactory<DoubleType>().create(dims, new DoubleType()), n, dims,
+				Double.class, (i) -> Tensors.tensorDoubleDirect(i));
+
+		// FloatType
+		testImg2TensorDirectTyped(new ArrayImgFactory<FloatType>().create(dims, new FloatType()), n, dims,
+				Float.class, (i) -> Tensors.tensorFloatDirect(i));
+
+		// IntType
+		testImg2TensorDirectTyped(new ArrayImgFactory<IntType>().create(dims, new IntType()), n, dims,
+				Integer.class, (i) -> Tensors.tensorIntDirect(i));
+
+		// LongType
+		testImg2TensorDirectTyped(new ArrayImgFactory<LongType>().create(dims, new LongType()), n, dims,
+				Long.class, (i) -> Tensors.tensorLongDirect(i));
+	}
+
+	/** Tests the tensor<Type>(RAI, int[]) function */
+	@Test
+	public void testImgToTensorMappingTyped() {
+		assertEquals(1, 1);
+
+		final long[] dims = new long[] { 5, 4, 3, 2 };
+		final int[] mapping = new int[] { 1, 3, 0, 2 }; // A strange mapping
+		final long[] shape = new long[] { 3, 5, 2, 4 };
+		final int n = dims.length;
+
+		// ByteType
+		testImg2TensorMappingTyped(new ArrayImgFactory<ByteType>().create(dims, new ByteType()), mapping, n, shape,
+				UInt8.class, (i) -> Tensors.tensorByte(i, mapping));
+
+		// DoubleType
+		testImg2TensorMappingTyped(new ArrayImgFactory<DoubleType>().create(dims, new DoubleType()), mapping, n, shape,
+				Double.class, (i) -> Tensors.tensorDouble(i, mapping));
+
+		// FloatType
+		testImg2TensorMappingTyped(new ArrayImgFactory<FloatType>().create(dims, new FloatType()), mapping, n, shape,
+				Float.class, (i) -> Tensors.tensorFloat(i, mapping));
+
+		// IntType
+		testImg2TensorMappingTyped(new ArrayImgFactory<IntType>().create(dims, new IntType()), mapping, n, shape,
+				Integer.class, (i) -> Tensors.tensorInt(i, mapping));
+
+		// LongType
+		testImg2TensorMappingTyped(new ArrayImgFactory<LongType>().create(dims, new LongType()), mapping, n, shape,
+				Long.class, (i) -> Tensors.tensorLong(i, mapping));
+	}
+
 	/** Tests the tensor(RAI) function for one image */
-	private <T extends RealType<T>> void testImg2TensorReverseForType(final Img<T> img, final int n, final long[] shape,
+	private <T extends RealType<T>> void testImg2TensorReverse(final Img<T> img, final int n, final long[] shape,
 			final DataType t) {
 		// Put some values to check into the image
 		List<Point> points = createTestPoints(n);
@@ -318,7 +410,7 @@ public class TensorsTest {
 	}
 
 	/** Tests the tensorDirect(RAI) function for one image */
-	private <T extends RealType<T>> void testImg2TensorDirectForType(final Img<T> img, final int n, final long[] shape,
+	private <T extends RealType<T>> void testImg2TensorDirect(final Img<T> img, final int n, final long[] shape,
 			final DataType t) {
 		// Put some values to check into the image
 		List<Point> points = createTestPoints(n);
@@ -333,7 +425,7 @@ public class TensorsTest {
 	}
 
 	/** Tests the tensor(RAI, int[]) function for one image */
-	private <T extends RealType<T>> void testImg2TensorMappingForType(final Img<T> img, final int[] mapping,
+	private <T extends RealType<T>> void testImg2TensorMapping(final Img<T> img, final int[] mapping,
 			final int n, final long[] shape, final DataType t) {
 		// Put some values to check into the image
 		List<Point> points = createTestPoints(n);
@@ -343,6 +435,51 @@ public class TensorsTest {
 		assertArrayEquals(shape, tensor.shape());
 		assertEquals(n, tensor.numDimensions());
 		assertEquals(t, tensor.dataType());
+		checkPointsTensor(tensor, mapping, points);
+	}
+
+	/** Tests the tensor<Type>(RAI) typed function for one image */
+	private <T extends RealType<T>, U> void testImg2TensorReverseTyped(final Img<T> img, final int n, final long[] shape,
+			Class<U> t, final Function<Img<T>, Tensor<U>> converter) {
+		// Put some values to check into the image
+		List<Point> points = createTestPoints(n);
+		markPoints(img, points);
+
+		Tensor<U> tensor = converter.apply(img);
+
+		assertArrayEquals(shape, tensor.shape());
+		assertEquals(n, tensor.numDimensions());
+		assertEquals(DataType.fromClass(t), tensor.dataType());
+		checkPointsTensor(tensor, IntStream.range(0, n).map(i -> n - 1 - i).toArray(), points);
+	}
+
+	/** Tests the tensor<Type>Direct(RAI) typed function for one image */
+	private <T extends RealType<T>, U> void testImg2TensorDirectTyped(final Img<T> img, final int n, final long[] shape,
+			Class<U> t, final Function<Img<T>, Tensor<U>> converter) {
+		// Put some values to check into the image
+		List<Point> points = createTestPoints(n);
+		markPoints(img, points);
+
+		Tensor<U> tensor = converter.apply(img);
+
+		assertArrayEquals(shape, tensor.shape());
+		assertEquals(n, tensor.numDimensions());
+		assertEquals(DataType.fromClass(t), tensor.dataType());
+		checkPointsTensor(tensor, IntStream.range(0, n).toArray(), points);
+	}
+
+	/** Tests the tensor<Type>(RAI, int[]) typed function for one image */
+	private <T extends RealType<T>, U> void testImg2TensorMappingTyped(final Img<T> img, final int[] mapping, final int n,
+			final long[] shape, Class<U> t, final Function<Img<T>, Tensor<U>> converter) {
+		// Put some values to check into the image
+		List<Point> points = createTestPoints(n);
+		markPoints(img, points);
+
+		Tensor<U> tensor = converter.apply(img);
+
+		assertArrayEquals(shape, tensor.shape());
+		assertEquals(n, tensor.numDimensions());
+		assertEquals(DataType.fromClass(t), tensor.dataType());
 		checkPointsTensor(tensor, mapping, points);
 	}
 

--- a/src/test/java/net/imagej/tensorflow/TensorsTest.java
+++ b/src/test/java/net/imagej/tensorflow/TensorsTest.java
@@ -80,27 +80,27 @@ public class TensorsTest {
 		// Create Tensors of different type and convert them to images
 		ByteBuffer dataByte = ByteBuffer.allocateDirect(size);
 		execForPointsWithBufferIndex(shape, mapping, points, (i, v) -> dataByte.put(i, (byte) (int) v));
-		Tensor tensorByte = Tensor.create(UInt8.class, shape, dataByte);
+		Tensor<UInt8> tensorByte = Tensor.create(UInt8.class, shape, dataByte);
 		Img<ByteType> imgByte = Tensors.imgByte(tensorByte);
 
 		DoubleBuffer dataDouble = DoubleBuffer.allocate(size);
 		execForPointsWithBufferIndex(shape, mapping, points, (i, v) -> dataDouble.put(i, v));
-		Tensor tensorDouble = Tensor.create(shape, dataDouble);
+		Tensor<Double> tensorDouble = Tensor.create(shape, dataDouble);
 		Img<DoubleType> imgDouble = Tensors.imgDouble(tensorDouble);
 
 		FloatBuffer dataFloat = FloatBuffer.allocate(size);
 		execForPointsWithBufferIndex(shape, mapping, points, (i, v) -> dataFloat.put(i, v));
-		Tensor tensorFloat = Tensor.create(shape, dataFloat);
+		Tensor<Float> tensorFloat = Tensor.create(shape, dataFloat);
 		Img<FloatType> imgFloat = Tensors.imgFloat(tensorFloat);
 
 		IntBuffer dataInt = IntBuffer.allocate(size);
 		execForPointsWithBufferIndex(shape, mapping, points, (i, v) -> dataInt.put(i, v));
-		Tensor tensorInt = Tensor.create(shape, dataInt);
+		Tensor<Integer> tensorInt = Tensor.create(shape, dataInt);
 		Img<IntType> imgInt = Tensors.imgInt(tensorInt);
 
 		LongBuffer dataLong = LongBuffer.allocate(size);
 		execForPointsWithBufferIndex(shape, mapping, points, (i, v) -> dataLong.put(i, v));
-		Tensor tensorLong = Tensor.create(shape, dataLong);
+		Tensor<Long> tensorLong = Tensor.create(shape, dataLong);
 		Img<LongType> imgLong = Tensors.imgLong(tensorLong);
 
 		// Check all created images
@@ -125,27 +125,27 @@ public class TensorsTest {
 		// Create Tensors of different type and convert them to images
 		ByteBuffer dataByte = ByteBuffer.allocateDirect(size);
 		execForPointsWithBufferIndex(shape, mapping, points, (i, v) -> dataByte.put(i, (byte) (int) v));
-		Tensor tensorByte = Tensor.create(UInt8.class, shape, dataByte);
+		Tensor<UInt8> tensorByte = Tensor.create(UInt8.class, shape, dataByte);
 		Img<ByteType> imgByte = Tensors.imgByteDirect(tensorByte);
 
 		DoubleBuffer dataDouble = DoubleBuffer.allocate(size);
 		execForPointsWithBufferIndex(shape, mapping, points, (i, v) -> dataDouble.put(i, v));
-		Tensor tensorDouble = Tensor.create(shape, dataDouble);
+		Tensor<Double> tensorDouble = Tensor.create(shape, dataDouble);
 		Img<DoubleType> imgDouble = Tensors.imgDoubleDirect(tensorDouble);
 
 		FloatBuffer dataFloat = FloatBuffer.allocate(size);
 		execForPointsWithBufferIndex(shape, mapping, points, (i, v) -> dataFloat.put(i, v));
-		Tensor tensorFloat = Tensor.create(shape, dataFloat);
+		Tensor<Float> tensorFloat = Tensor.create(shape, dataFloat);
 		Img<FloatType> imgFloat = Tensors.imgFloatDirect(tensorFloat);
 
 		IntBuffer dataInt = IntBuffer.allocate(size);
 		execForPointsWithBufferIndex(shape, mapping, points, (i, v) -> dataInt.put(i, v));
-		Tensor tensorInt = Tensor.create(shape, dataInt);
+		Tensor<Integer> tensorInt = Tensor.create(shape, dataInt);
 		Img<IntType> imgInt = Tensors.imgIntDirect(tensorInt);
 
 		LongBuffer dataLong = LongBuffer.allocate(size);
 		execForPointsWithBufferIndex(shape, mapping, points, (i, v) -> dataLong.put(i, v));
-		Tensor tensorLong = Tensor.create(shape, dataLong);
+		Tensor<Long> tensorLong = Tensor.create(shape, dataLong);
 		Img<LongType> imgLong = Tensors.imgLongDirect(tensorLong);
 
 		// Check all created images
@@ -171,27 +171,27 @@ public class TensorsTest {
 		// Create Tensors of different type and convert them to images
 		ByteBuffer dataByte = ByteBuffer.allocateDirect(size);
 		execForPointsWithBufferIndex(shape, mapping, points, (i, v) -> dataByte.put(i, (byte) (int) v));
-		Tensor tensorByte = Tensor.create(UInt8.class, shape, dataByte);
+		Tensor<UInt8> tensorByte = Tensor.create(UInt8.class, shape, dataByte);
 		Img<ByteType> imgByte = Tensors.imgByte(tensorByte, mapping);
 
 		DoubleBuffer dataDouble = DoubleBuffer.allocate(size);
 		execForPointsWithBufferIndex(shape, mapping, points, (i, v) -> dataDouble.put(i, v));
-		Tensor tensorDouble = Tensor.create(shape, dataDouble);
+		Tensor<Double> tensorDouble = Tensor.create(shape, dataDouble);
 		Img<DoubleType> imgDouble = Tensors.imgDouble(tensorDouble, mapping);
 
 		FloatBuffer dataFloat = FloatBuffer.allocate(size);
 		execForPointsWithBufferIndex(shape, mapping, points, (i, v) -> dataFloat.put(i, v));
-		Tensor tensorFloat = Tensor.create(shape, dataFloat);
+		Tensor<Float> tensorFloat = Tensor.create(shape, dataFloat);
 		Img<FloatType> imgFloat = Tensors.imgFloat(tensorFloat, mapping);
 
 		IntBuffer dataInt = IntBuffer.allocate(size);
 		execForPointsWithBufferIndex(shape, mapping, points, (i, v) -> dataInt.put(i, v));
-		Tensor tensorInt = Tensor.create(shape, dataInt);
+		Tensor<Integer> tensorInt = Tensor.create(shape, dataInt);
 		Img<IntType> imgInt = Tensors.imgInt(tensorInt, mapping);
 
 		LongBuffer dataLong = LongBuffer.allocate(size);
 		execForPointsWithBufferIndex(shape, mapping, points, (i, v) -> dataLong.put(i, v));
-		Tensor tensorLong = Tensor.create(shape, dataLong);
+		Tensor<Long> tensorLong = Tensor.create(shape, dataLong);
 		Img<LongType> imgLong = Tensors.imgLong(tensorLong, mapping);
 
 		// Check all created images
@@ -309,7 +309,7 @@ public class TensorsTest {
 		List<Point> points = createTestPoints(n);
 		markPoints(img, points);
 
-		Tensor tensor = Tensors.tensor(img);
+		Tensor<?> tensor = Tensors.tensor(img);
 
 		assertArrayEquals(shape, tensor.shape());
 		assertEquals(n, tensor.numDimensions());
@@ -324,7 +324,7 @@ public class TensorsTest {
 		List<Point> points = createTestPoints(n);
 		markPoints(img, points);
 
-		Tensor tensor = Tensors.tensorDirect(img);
+		Tensor<?> tensor = Tensors.tensorDirect(img);
 
 		assertArrayEquals(shape, tensor.shape());
 		assertEquals(n, tensor.numDimensions());
@@ -338,7 +338,7 @@ public class TensorsTest {
 		// Put some values to check into the image
 		List<Point> points = createTestPoints(n);
 		markPoints(img, points);
-		Tensor tensor = Tensors.tensor(img, mapping);
+		Tensor<?> tensor = Tensors.tensor(img, mapping);
 
 		assertArrayEquals(shape, tensor.shape());
 		assertEquals(n, tensor.numDimensions());
@@ -397,7 +397,7 @@ public class TensorsTest {
 	}
 
 	/** Checks the given points for the given tensor */
-	private void checkPointsTensor(final Tensor tensor, final int[] mapping, final List<Point> points) {
+	private void checkPointsTensor(final Tensor<?> tensor, final int[] mapping, final List<Point> points) {
 		switch (tensor.dataType()) {
 		case UINT8: {
 			ByteBuffer buffer = ByteBuffer.allocate(tensor.numElements());


### PR DESCRIPTION
Update to TensorFlow 1.4.

This PR doesn't break our API but the TensorFlow API is different.
For example:
`Tensor.create(DataType, long[], ByteBuffer)` is now `Tensor.create(Class, long[], ByteBuffer)`.

I added some functions to the Tensors class which provide typesafe creation of tensors. (And unit tests for them)