### PR TITLE
Update to TensorFlow 1.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>17.1.1</version>
+		<version>19.2.0</version>
 		<relativePath />
 	</parent>
 
@@ -93,7 +93,7 @@ Wisconsin-Madison and Google, Inc.</license.copyrightOwners>
 		<releaseProfiles>deploy-to-imagej</releaseProfiles>
 
 		<!-- Override tensorflow version -->
-		<tensorflow.version>1.4.0</tensorflow.version>
+		<tensorflow.version>1.6.0</tensorflow.version>
 	</properties>
 
 	<repositories>


### PR DESCRIPTION
The current repository is running on TensorFlow 1.2.0. Minor changes needed to be made to make sure the example still ran properly since the previous methods `LabelImage.java` used were made private in TensorFlow. There still appear to be errors in `TensorsTest.java`.