### PR TITLE
Cache loaded models during runtime

### DIFF
--- a/src/main/java/net/imagej/tensorflow/DefaultTensorFlowService.java
+++ b/src/main/java/net/imagej/tensorflow/DefaultTensorFlowService.java
@@ -119,6 +119,9 @@ public class DefaultTensorFlowService extends AbstractService implements TensorF
 		final SavedModelBundle model = //
 			SavedModelBundle.load(modelDir.getAbsolutePath(), tags);
 
+		// Cache the result for performance next time.
+		models.put(key, model);
+
 		return model;
 	}
 


### PR DESCRIPTION
This adds a loaded model to a Hashmap to be able to load it faster the next time. We already do the same for graphs and labels, I think this line just got lost?