### PR TITLE
Add Command to manage TensorFlow library versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,30 @@
 				<role>maintainer</role>
 			</roles>
 		</developer>
+		<developer>
+			<id>HedgehogCode</id>
+			<name>Benjamin Wilhelm</name>
+			<url>https://imagej.net/User:Bwilhelm</url>
+			<roles>
+				<role>developer</role>
+				<role>debugger</role>
+				<role>reviewer</role>
+				<role>support</role>
+				<role>maintainer</role>
+			</roles>
+		</developer>
+		<developer>
+			<id>frauzufall</id>
+			<name>Deborah Schmidt</name>
+			<url>https://imagej.net/User:Frauzufall</url>
+			<roles>
+				<role>developer</role>
+				<role>debugger</role>
+				<role>reviewer</role>
+				<role>support</role>
+				<role>maintainer</role>
+			</roles>
+		</developer>
 	</developers>
 	<contributors>
 		<contributor>

--- a/pom.xml
+++ b/pom.xml
@@ -124,5 +124,10 @@ Wisconsin-Madison and Google, Inc.</license.copyrightOwners>
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-compress</artifactId>
+			<version>1.11</version>
+		</dependency>
 	</dependencies>
 </project>

--- a/src/main/java/net/imagej/tensorflow/DefaultTensorFlowService.java
+++ b/src/main/java/net/imagej/tensorflow/DefaultTensorFlowService.java
@@ -48,6 +48,7 @@ import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
+import net.imagej.tensorflow.util.TensorFlowUtil;
 import org.scijava.app.AppService;
 import org.scijava.app.StatusService;
 import org.scijava.download.DiskLocationCache;
@@ -55,6 +56,7 @@ import org.scijava.download.DownloadService;
 import org.scijava.event.EventHandler;
 import org.scijava.io.location.BytesLocation;
 import org.scijava.io.location.Location;
+import org.scijava.log.LogService;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.service.AbstractService;
@@ -65,6 +67,7 @@ import org.scijava.util.ByteArray;
 import org.scijava.util.FileUtils;
 import org.tensorflow.Graph;
 import org.tensorflow.SavedModelBundle;
+import org.tensorflow.TensorFlow;
 
 /**
  * Default implementation of {@link TensorFlowService}.
@@ -72,8 +75,7 @@ import org.tensorflow.SavedModelBundle;
  * @author Curtis Rueden
  */
 @Plugin(type = Service.class)
-public class DefaultTensorFlowService extends AbstractService implements
-	TensorFlowService
+public class DefaultTensorFlowService extends AbstractService implements TensorFlowService
 {
 
 	@Parameter
@@ -81,6 +83,9 @@ public class DefaultTensorFlowService extends AbstractService implements
 
 	@Parameter
 	private AppService appService;
+
+	@Parameter
+	private LogService logService;
 
 	/** Models which are already cached in memory. */
 	private final Map<String, SavedModelBundle> models = new HashMap<>();
@@ -93,6 +98,11 @@ public class DefaultTensorFlowService extends AbstractService implements
 
 	/** Disk cache defining where compressed models are stored locally. */
 	private DiskLocationCache modelCache;
+
+	private TensorFlowLibraryStatus tfStatus = TensorFlowLibraryStatus.notLoaded();
+
+	/** The loaded TensorFlow version. Will be initialized once in loadLibrary */
+	private TensorFlowVersion tfVersion;
 
 	// -- TensorFlowService methods --
 
@@ -166,6 +176,128 @@ public class DefaultTensorFlowService extends AbstractService implements
 		labelses.put(key, labels);
 
 		return labels;
+	}
+
+	/**
+	 * Loads the TensorFlow library.
+	 */
+	@Override
+	public synchronized void loadLibrary() {
+		// Do not try to load the library twice
+		if (tfStatus.triedLoading())
+			return;
+
+		// Handle a previous crash
+		boolean jniCrashed = false;
+		boolean jarCrashed = false;
+		if (getCrashFile().exists()) {
+			logService.warn("Crash file exists: " + getCrashFile().getAbsolutePath());
+			if (getNativeVersionFile().exists()) {
+				// The jni library crashed the JVM: We should test if the jar library works
+				jniCrashed = true;
+				tfStatus = TensorFlowLibraryStatus.crashed("TensorFlow native library crashed: ");
+				logService.warn("The JVM seems to have crashed when loading the TensorFlow native library.");
+				logService.warn("Trying to delete TensorFlow libraries from " + TensorFlowUtil.getLibDir(getRoot()));
+				TensorFlowUtil.removeNativeLibraries(getRoot(), logService);
+				logService.warn("Trying to load the library provided by this JAR instead:" + TensorFlowUtil.getTensorFlowJAR());
+			} else {
+				// The jar library crashed the JVM: We should not try to load it again
+				jarCrashed = true;
+				tfStatus = TensorFlowLibraryStatus.crashed("TensorFlow JAR crashed: " + TensorFlowUtil.getTensorFlowJAR());
+				logService.warn("The JVM seems to have crashed when loading the TensorFlow JAR library: " + TensorFlowUtil.getTensorFlowJAR());
+				logService.warn("Please run Edit > Options > TensorFlow and choose another version or delete the crash file to load the JAR library again.");
+			}
+		}
+
+		if(!jarCrashed) {
+
+			createCrashFile();
+
+			if (jniCrashed) {
+				// jni crashed, ignore jni and load jar
+				tfStatus =  loadFromJAR();
+			} else {
+				tfStatus = loadFromLib();
+				if(!tfStatus.isFailed() && !tfStatus.isLoaded()) {
+					// no jni present, load jar
+					tfStatus = loadFromJAR();
+				}
+			}
+
+			deleteCrashFile();
+
+			if(!tfStatus.isLoaded() && !tfStatus.isFailed()) {
+				tfStatus = TensorFlowLibraryStatus.failed("Could not find any TensorFlow library.");
+			}
+		}
+
+	}
+
+	/**
+	 * Tries to load the TensorFlow library from Fiji.app/lib folder.
+	 * In case of success, {@link #tfVersion} is set to the loaded TensorFlow version
+	 * @return the {@link TensorFlowLibraryStatus} indicating success or failure of loading the library
+	 */
+	private TensorFlowLibraryStatus loadFromLib() {
+		try {
+			System.loadLibrary("tensorflow_jni");
+			try {
+				tfVersion = TensorFlowUtil.readNativeVersionFile(getRoot());
+			} catch (IOException e) {
+				// could not read native version file, unknown version origin
+				logService.warn(e.getMessage());
+				tfVersion = new TensorFlowVersion(TensorFlow.version(), null, null, null);
+			}
+			return TensorFlowLibraryStatus.loaded("Using native TensorFlow version: " + tfVersion);
+		} catch (final UnsatisfiedLinkError e) {
+			if(e.getMessage().contains("no tensorflow_jni")) {
+				logService.info("No TF library found in " + TensorFlowUtil.getLibDir(getRoot()) + ".");
+				return TensorFlowLibraryStatus.notLoaded();
+			} else {
+				try {
+					TensorFlowVersion failingVersion = TensorFlowUtil.readNativeVersionFile(getRoot());
+					logService.warn("Could not load native TF library " + failingVersion + " " + e.getMessage());
+				} catch (IOException e1) {
+					logService.warn("Could not load native TF library (unknown version) " + e.getMessage());
+				}
+				// TODO maybe ask if the native lib should be deleted from /lib
+				return TensorFlowLibraryStatus.failed( e.getMessage());
+			}
+		}
+	}
+
+	/**
+	 * Tries to load the TensorFlow library from the TensorFlow JAR in the class path.
+	 * In case of success, {@link #tfVersion} is set to the loaded TensorFlow version
+	 * @return the {@link TensorFlowLibraryStatus} indicating success or failure of loading the library
+	 */
+	private TensorFlowLibraryStatus loadFromJAR() {
+		// Calling a native method will load the library from the jar
+		try {
+			tfVersion = getJarVersion();
+			return TensorFlowLibraryStatus.loaded("Using default TensorFlow version from JAR: " + tfVersion);
+		} catch (UnsatisfiedLinkError | NoClassDefFoundError e) {
+			logService.warn("Could not load JAR TF library: " + e.getMessage());
+			return TensorFlowLibraryStatus.failed(e.getMessage());
+		}
+	}
+
+	private File getNativeVersionFile() {
+		return TensorFlowUtil.getNativeVersionFile(getRoot());
+	}
+
+	private File getCrashFile() {
+		return TensorFlowUtil.getCrashFile(getRoot());
+	}
+
+	@Override
+	public synchronized TensorFlowVersion getTensorFlowVersion() {
+		return tfVersion;
+	}
+
+	@Override
+	public synchronized TensorFlowLibraryStatus getStatus() {
+		return tfStatus;
 	}
 
 	// -- Disposable methods --
@@ -270,6 +402,36 @@ public class DefaultTensorFlowService extends AbstractService implements
 			}
 		}
 		statusUpdater.clear();
+	}
+
+	private void createCrashFile() {
+		try {
+			getCrashFile().getParentFile().mkdirs();
+			getCrashFile().createNewFile();
+		} catch (final IOException e) {
+			logService.warn(e);
+		}
+	}
+
+	private void deleteCrashFile() {
+		final File crashFile = getCrashFile();
+		if(crashFile.exists()) crashFile.delete();
+	}
+
+	private TensorFlowVersion getJarVersion() {
+		TensorFlowVersion version = TensorFlowUtil.versionFromClassPathJAR();
+		String loadedVersion = TensorFlow.version();
+		if(!version.getVersionNumber().equals(loadedVersion)) {
+			logService.warn("Loaded TensorFlow version is " + loadedVersion
+					+ " whereas the TensorFlow class in the classpath suggests version "
+					+ version.getVersionNumber() + ".");
+			return new TensorFlowVersion(loadedVersion, null, null, null);
+		}
+		return version;
+	}
+
+	private String getRoot() {
+		return appService.getApp().getBaseDirectory().getAbsolutePath();
 	}
 
 	/**

--- a/src/main/java/net/imagej/tensorflow/TensorFlowLibraryStatus.java
+++ b/src/main/java/net/imagej/tensorflow/TensorFlowLibraryStatus.java
@@ -1,0 +1,103 @@
+/*-
+ * #%L
+ * ImageJ/TensorFlow integration.
+ * %%
+ * Copyright (C) 2019 Board of Regents of the University of
+ * Wisconsin-Madison and Google, Inc.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.tensorflow;
+
+/**
+ * The loading status of the TensorFlow native library.
+ * @author Deborah Schmidt
+ * @author Benjamin Wilhelm
+ */
+public final class TensorFlowLibraryStatus {
+
+	private final boolean loaded;
+	private final boolean crashed;
+	private final boolean failed;
+	private final String info;
+
+	static TensorFlowLibraryStatus notLoaded() {
+		return new TensorFlowLibraryStatus(false, false, false, "");
+	}
+
+	static TensorFlowLibraryStatus loaded(final String info) {
+		return new TensorFlowLibraryStatus(true, false, false, info);
+	}
+
+	static TensorFlowLibraryStatus crashed(final String info) {
+		return new TensorFlowLibraryStatus(false, true, false, info);
+	}
+
+	static TensorFlowLibraryStatus failed(final String info) {
+		return new TensorFlowLibraryStatus(false, false, true, info);
+	}
+
+	private TensorFlowLibraryStatus(final boolean loaded, final boolean crashed, final boolean failed,
+			final String info) {
+		this.loaded = loaded;
+		this.crashed = crashed;
+		this.failed = failed;
+		this.info = info;
+	}
+
+	/**
+	 * @return whether there was an attempt to load the TensorFlow library
+	 */
+	public boolean triedLoading() {
+		return loaded || crashed || failed;
+	}
+
+	/**
+	 * @return whether the TensorFlow library was successfully loaded
+	 */
+	public boolean isLoaded() {
+		return loaded;
+	}
+
+	/**
+	 * @return whether the TensorFlow library failed to load
+	 */
+	public boolean isFailed() {
+		return failed;
+	}
+
+	/**
+	 * @return whether a crash log file was found indicating that the TensorFlow library crashed the JVM during {@link TensorFlowService#loadLibrary()}
+	 */
+	public boolean isCrashed() {
+		return crashed;
+	}
+
+	/**
+	 * @return a message describing the failed or successful loading attempt of the TensorFlow Library
+	 */
+	public String getInfo() {
+		return info;
+	}
+}

--- a/src/main/java/net/imagej/tensorflow/TensorFlowService.java
+++ b/src/main/java/net/imagej/tensorflow/TensorFlowService.java
@@ -30,14 +30,13 @@
 
 package net.imagej.tensorflow;
 
-import java.io.IOException;
-import java.util.List;
-
 import net.imagej.ImageJService;
-
 import org.scijava.io.location.Location;
 import org.tensorflow.Graph;
 import org.tensorflow.SavedModelBundle;
+
+import java.io.IOException;
+import java.util.List;
 
 /**
  * Service for working with TensorFlow.
@@ -93,4 +92,20 @@ public interface TensorFlowService extends ImageJService {
 	 */
 	List<String> loadLabels(Location source, String modelName, String labelsPath)
 		throws IOException;
+
+	/**
+	 * Loads the TensorFlow Library.
+	 */
+	void loadLibrary();
+
+	/**
+	 * @return the TensorFlow version which is currently loaded.
+	 *         <code>null</code> if no version is loaded.
+	 */
+	TensorFlowVersion getTensorFlowVersion();
+
+	/**
+	 * @return Status information about the TensorFlow library (e.g. whether it crashed the application)
+	 */
+	TensorFlowLibraryStatus getStatus();
 }

--- a/src/main/java/net/imagej/tensorflow/TensorFlowVersion.java
+++ b/src/main/java/net/imagej/tensorflow/TensorFlowVersion.java
@@ -1,0 +1,129 @@
+/*-
+ * #%L
+ * ImageJ/TensorFlow integration.
+ * %%
+ * Copyright (C) 2019 Board of Regents of the University of
+ * Wisconsin-Madison and Google, Inc.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.tensorflow;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * A class describing the details of a specific TensorFlow version.
+ *
+ * @author Deborah Schmidt
+ * @author Benjamin Wilhelm
+ */
+public class TensorFlowVersion {
+
+	protected final String tfVersion;
+	protected final Optional<Boolean> supportsGPU;
+	protected Optional<String> cuda;
+	protected Optional<String> cudnn;
+
+	/**
+	 * @param version         the TensorFlow version number
+	 * @param supportsGPU     whether this version runs on the GPU
+	 * @param compatibleCUDA  the CUDA version compatible with this TensorFlow
+	 *                        version
+	 * @param compatibleCuDNN the CuDNN version compatible with this TensorFlow
+	 *                        version
+	 */
+	public TensorFlowVersion(final String version, final Boolean supportsGPU, final String compatibleCUDA,
+			final String compatibleCuDNN) {
+		this.tfVersion = version;
+		this.supportsGPU = Optional.ofNullable(supportsGPU);
+		this.cuda = Optional.ofNullable(compatibleCUDA);
+		this.cudnn = Optional.ofNullable(compatibleCuDNN);
+	}
+
+	public TensorFlowVersion(TensorFlowVersion other) {
+		this.tfVersion  = other.tfVersion;
+		this.supportsGPU = other.supportsGPU;
+		this.cuda = other.cuda;
+		this.cudnn = other.cudnn;
+	}
+
+	/**
+	 * @return the version number of TensorFlow, e.g. 0.13.1
+	 */
+	public String getVersionNumber() {
+		return tfVersion;
+	}
+
+	/**
+	 * @return if the version supports the usage of the GPU
+	 */
+	public Optional<Boolean> usesGPU() {
+		return supportsGPU;
+	}
+
+	/**
+	 * @return the CUDA version this TensorFlow version is compatible with
+	 */
+	public Optional<String> getCompatibleCUDA() {
+		return cuda;
+	}
+
+	/**
+	 * @return the CuDNN version this TensorFlow version is compatible with
+	 */
+	public Optional<String> getCompatibleCuDNN() {
+		return cudnn;
+	}
+
+	@Override
+	public boolean equals(final Object obj) {
+		if (!(obj.getClass().equals(this.getClass()))) return false;
+		final TensorFlowVersion o = (TensorFlowVersion) obj;
+		return tfVersion.equals(o.tfVersion) //
+				&& supportsGPU.equals(o.supportsGPU);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(tfVersion, supportsGPU, cuda, cudnn);
+	}
+
+	@Override
+	public String toString() {
+		String text = "TF " + tfVersion;
+		if(supportsGPU.isPresent()) text += " " + (supportsGPU.get() ? "GPU" : "CPU");
+		if (cuda.isPresent() || cudnn.isPresent()) {
+			text += " (";
+			if (cuda.isPresent())
+				text += "CUDA " + cuda.get();
+			if (cuda.isPresent() && cudnn.isPresent())
+				text += ", ";
+			if (cudnn.isPresent())
+				text += "CuDNN " + cudnn.get();
+			text += ")";
+		}
+		return text;
+	}
+}

--- a/src/main/java/net/imagej/tensorflow/demo/LabelImage.java
+++ b/src/main/java/net/imagej/tensorflow/demo/LabelImage.java
@@ -97,6 +97,11 @@ public class LabelImage implements Command {
 
 	@Override
 	public void run() {
+
+		tensorFlowService.loadLibrary();
+		if(!tensorFlowService.getStatus().isLoaded()) return;
+		log.info("Version of TensorFlow: " + tensorFlowService.getTensorFlowVersion());
+
 		try {
 			final HTTPLocation source = new HTTPLocation(INCEPTION_MODEL_URL);
 			final Graph graph = tensorFlowService.loadGraph(source, MODEL_NAME,

--- a/src/main/java/net/imagej/tensorflow/ui/AvailableTensorFlowVersions.java
+++ b/src/main/java/net/imagej/tensorflow/ui/AvailableTensorFlowVersions.java
@@ -1,0 +1,132 @@
+/*-
+ * #%L
+ * ImageJ/TensorFlow integration.
+ * %%
+ * Copyright (C) 2019 Board of Regents of the University of
+ * Wisconsin-Madison and Google, Inc.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.tensorflow.ui;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Utility class providing a hardcoded list of available native TensorFlow library versions which can be downloaded from the google servers.
+ *
+ * @author Deborah Schmidt
+ * @author Benjamin Wilhelm
+ */
+public class AvailableTensorFlowVersions {
+
+	/**
+	 * @return a list of downloadable native TensorFlow versions for all operating systems, including their URL and optionally their CUDA / CuDNN compatibility
+	 */
+	public static List<DownloadableTensorFlowVersion> get() {
+		List<DownloadableTensorFlowVersion> versions = new ArrayList<>();
+		versions.clear();
+		//linux64
+		versions.add(version("linux64", "1.2.0", "CPU", "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-cpu-linux-x86_64-1.2.0.tar.gz"));
+		versions.add(version("linux64", "1.2.0", "GPU", "8.0", "5.1", "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-gpu-linux-x86_64-1.2.0.tar.gz"));
+		versions.add(version("linux64", "1.3.0", "CPU", "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-cpu-linux-x86_64-1.3.0.tar.gz"));
+		versions.add(version("linux64", "1.3.0", "GPU", "8.0", "6", "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-gpu-linux-x86_64-1.3.0.tar.gz"));
+		versions.add(version("linux64", "1.4.1", "CPU", "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-cpu-linux-x86_64-1.4.1.tar.gz"));
+		versions.add(version("linux64", "1.4.1", "GPU", "8.0", "6", "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-gpu-linux-x86_64-1.4.1.tar.gz"));
+		versions.add(version("linux64", "1.5.0", "CPU", "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-cpu-linux-x86_64-1.5.0.tar.gz"));
+		versions.add(version("linux64", "1.5.0", "GPU", "9.0", "7", "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-gpu-linux-x86_64-1.5.0.tar.gz"));
+		versions.add(version("linux64", "1.6.0", "CPU", "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-cpu-linux-x86_64-1.6.0.tar.gz"));
+		versions.add(version("linux64", "1.6.0", "GPU", "9.0", "7", "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-gpu-linux-x86_64-1.6.0.tar.gz"));
+		versions.add(version("linux64", "1.7.0", "CPU", "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-cpu-linux-x86_64-1.7.0.tar.gz"));
+		versions.add(version("linux64", "1.7.0", "GPU", "9.0", "7", "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-gpu-linux-x86_64-1.7.0.tar.gz"));
+		versions.add(version("linux64", "1.8.0", "CPU", "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-cpu-linux-x86_64-1.8.0.tar.gz"));
+		versions.add(version("linux64", "1.8.0", "GPU", "9.0", "7", "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-gpu-linux-x86_64-1.8.0.tar.gz"));
+		versions.add(version("linux64", "1.9.0", "CPU", "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-cpu-linux-x86_64-1.9.0.tar.gz"));
+		versions.add(version("linux64", "1.9.0", "GPU", "9.0", "7", "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-gpu-linux-x86_64-1.9.0.tar.gz"));
+		versions.add(version("linux64", "1.10.1", "CPU", "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-cpu-linux-x86_64-1.10.1.tar.gz"));
+		versions.add(version("linux64", "1.10.1", "GPU", "9.0", "7.?", "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-gpu-linux-x86_64-1.10.1.tar.gz"));
+		versions.add(version("linux64", "1.11.0", "CPU", "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-cpu-linux-x86_64-1.11.0.tar.gz"));
+		versions.add(version("linux64", "1.11.0", "GPU", "9.0", ">= 7.2", "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-gpu-linux-x86_64-1.11.0.tar.gz"));
+		versions.add(version("linux64", "1.12.0", "CPU", "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-cpu-linux-x86_64-1.12.0.tar.gz"));
+		versions.add(version("linux64", "1.12.0", "GPU", "9.0", ">= 7.2", "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-gpu-linux-x86_64-1.12.0.tar.gz"));
+		versions.add(version("linux64", "1.13.1", "CPU", "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-cpu-linux-x86_64-1.13.1.tar.gz"));
+		versions.add(version("linux64", "1.13.1", "GPU", "10.0", "7.4", "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-gpu-linux-x86_64-1.13.1.tar.gz"));
+		versions.add(version("linux64", "1.14.0", "CPU", "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-cpu-linux-x86_64-1.14.0.tar.gz"));
+		versions.add(version("linux64", "1.14.0", "GPU", "10.0", ">= 7.4.1", "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-gpu-linux-x86_64-1.14.0.tar.gz"));
+		//win64
+		versions.add(version("win64", "1.2.0", "CPU", "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-cpu-windows-x86_64-1.2.0.zip"));
+		versions.add(version("win64", "1.3.0", "CPU", "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-cpu-windows-x86_64-1.3.0.zip"));
+		versions.add(version("win64", "1.4.1", "CPU", "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-cpu-windows-x86_64-1.4.1.zip"));
+		versions.add(version("win64", "1.5.0", "CPU", "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-cpu-windows-x86_64-1.5.0.zip"));
+		versions.add(version("win64", "1.6.0", "CPU", "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-cpu-windows-x86_64-1.6.0.zip"));
+		versions.add(version("win64", "1.7.0", "CPU", "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-cpu-windows-x86_64-1.7.0.zip"));
+		versions.add(version("win64", "1.8.0", "CPU", "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-cpu-windows-x86_64-1.8.0.zip"));
+		versions.add(version("win64", "1.9.0", "CPU", "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-cpu-windows-x86_64-1.9.0.zip"));
+		versions.add(version("win64", "1.10.0", "CPU", "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-cpu-windows-x86_64-1.10.0.zip"));
+		versions.add(version("win64", "1.11.0", "CPU", "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-cpu-windows-x86_64-1.11.0.zip"));
+		versions.add(version("win64", "1.12.0", "GPU", "9.0", ">= 7.2", "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-gpu-windows-x86_64-1.12.0.zip"));
+		versions.add(version("win64", "1.12.0", "CPU", "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-cpu-windows-x86_64-1.12.0.zip"));
+		versions.add(version("win64", "1.13.1", "GPU", "10.0", "7.4", "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-gpu-windows-x86_64-1.13.1.zip"));
+		versions.add(version("win64", "1.13.1", "CPU", "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-cpu-windows-x86_64-1.13.1.zip"));
+		versions.add(version("win64", "1.14.0", "GPU", "10.0", ">= 7.4.1", "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-gpu-windows-x86_64-1.14.0.zip"));
+		versions.add(version("win64", "1.14.0", "CPU", "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-cpu-windows-x86_64-1.14.0.zip"));
+		//macosx
+		versions.add(version("macosx", "1.2.0", "CPU", "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-cpu-darwin-x86_64-1.2.0.tar.gz"));
+		versions.add(version("macosx", "1.3.0", "CPU", "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-cpu-darwin-x86_64-1.3.0.tar.gz"));
+		versions.add(version("macosx", "1.4.1", "CPU", "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-cpu-darwin-x86_64-1.4.1.tar.gz"));
+		versions.add(version("macosx", "1.5.0", "CPU", "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-cpu-darwin-x86_64-1.5.0.tar.gz"));
+		versions.add(version("macosx", "1.6.0", "CPU", "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-cpu-darwin-x86_64-1.6.0.tar.gz"));
+		versions.add(version("macosx", "1.7.0", "CPU", "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-cpu-darwin-x86_64-1.7.0.tar.gz"));
+		versions.add(version("macosx", "1.8.0", "CPU", "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-cpu-darwin-x86_64-1.8.0.tar.gz"));
+		versions.add(version("macosx", "1.9.0", "CPU", "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-cpu-darwin-x86_64-1.9.0.tar.gz"));
+		versions.add(version("macosx", "1.10.1", "CPU", "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-cpu-darwin-x86_64-1.10.1.tar.gz"));
+		versions.add(version("macosx", "1.11.0", "CPU", "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-cpu-darwin-x86_64-1.11.0.tar.gz"));
+		versions.add(version("macosx", "1.12.0", "CPU", "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-cpu-darwin-x86_64-1.12.0.tar.gz"));
+		versions.add(version("macosx", "1.13.1", "CPU", "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-cpu-darwin-x86_64-1.13.1.tar.gz"));
+		versions.add(version("macosx", "1.14.0", "CPU", "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow_jni-cpu-darwin-x86_64-1.14.0.tar.gz"));
+		return versions;
+	}
+
+	private static DownloadableTensorFlowVersion version(String platform, String tensorFlowVersion, String mode, String url) {
+		DownloadableTensorFlowVersion version = new DownloadableTensorFlowVersion(tensorFlowVersion, mode.equals("GPU"));
+		try {
+			version.setURL(new URL(url));
+		} catch (MalformedURLException e) {
+			e.printStackTrace();
+		}
+		version.setPlatform(platform);
+		return version;
+	}
+
+	private static DownloadableTensorFlowVersion version(String platform, String tensorFlowVersion, String mode, String cuda, String cudnn, String url) {
+		try {
+			return new DownloadableTensorFlowVersion(new URL(url), tensorFlowVersion, platform, mode.equals("GPU"), cuda, cudnn);
+		} catch (MalformedURLException e) {
+			e.printStackTrace();
+			return null;
+		}
+	}
+}

--- a/src/main/java/net/imagej/tensorflow/ui/DownloadableTensorFlowVersion.java
+++ b/src/main/java/net/imagej/tensorflow/ui/DownloadableTensorFlowVersion.java
@@ -1,0 +1,172 @@
+/*-
+ * #%L
+ * ImageJ/TensorFlow integration.
+ * %%
+ * Copyright (C) 2019 Board of Regents of the University of
+ * Wisconsin-Madison and Google, Inc.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.tensorflow.ui;
+
+import net.imagej.tensorflow.TensorFlowVersion;
+
+import java.net.URL;
+import java.util.Objects;
+
+/**
+ * This class extends {@link TensorFlowVersion} with knowledge about the web source of this version, the matching platform and whether it has already been downloaded.
+ *
+ * @author Deborah Schmidt
+ * @author Benjamin Wilhelm
+ */
+class DownloadableTensorFlowVersion extends TensorFlowVersion {
+	private URL url;
+	private String platform;
+	private String localPath;
+
+	private boolean active = false;
+	private boolean downloaded = false;
+
+	/**
+	 * @param url the URL of the packed JNI file
+	 * @param version the TensorFlow version number
+	 * @param os the platform this version is associated with
+	 * @param supportsGPU whether this version runs on the GPU
+	 * @param compatibleCUDA the CUDA version compatible with this TensorFlow version
+	 * @param compatibleCuDNN the CuDNN version compatible with this TensorFlow version
+	 */
+	DownloadableTensorFlowVersion(URL url, String version, String os, boolean supportsGPU, String compatibleCUDA, String compatibleCuDNN) {
+		super(version, supportsGPU, compatibleCUDA, compatibleCuDNN);
+		this.platform = os;
+		this.url = url;
+	}
+
+	/**
+	 * @param version the TensorFlow version number
+	 * @param supportsGPU whether this version runs on the GPU
+	 */
+	DownloadableTensorFlowVersion(String version, boolean supportsGPU) {
+		super(version, supportsGPU, null, null);
+	}
+
+	DownloadableTensorFlowVersion(TensorFlowVersion other) {
+		super(other);
+	}
+
+	/**
+	 * @return the URL where an archive of this version can be downloaded from
+	 */
+	public URL getURL() {
+		return url;
+	}
+
+	void setURL(URL url) {
+		this.url = url;
+	}
+
+	/**
+	 * @return the platform this version is associated with (linux64, linux32, win64, win32, macosx)
+	 */
+	public String getPlatform() {
+		return platform;
+	}
+
+	void setPlatform(String platform) {
+		this.platform = platform;
+	}
+
+	/**
+	 * @return the path this version is cached to
+	 */
+	public String getLocalPath() {
+		return localPath;
+	}
+
+	/**
+	 * @return whether this version is currently being used
+	 */
+	public boolean isActive() {
+		return active;
+	}
+
+	void setActive(boolean active) {
+		this.active = active;
+	}
+
+	/**
+	 * @return whether this version is cashed to a local path
+	 */
+	public boolean isCached() {
+		return downloaded;
+	}
+
+	/**
+	 * @return String describing the origin of this version
+	 */
+	public String getOriginDescription() {
+		if(downloaded) return localPath;
+		return url.toString();
+	}
+
+	/**
+	 * @return the TensorFlow version number in an easily comparable format (e.g. 0.13.1 to 000.013.001)
+	 */
+	String getComparableTFVersion() {
+		String orderableVersion = "";
+		String[] split = tfVersion.split("\\.");
+		for(String part : split) {
+			orderableVersion += String.format("%03d%n", Integer.valueOf(part));
+		}
+		return orderableVersion;
+	}
+
+	void setCached(String localPath) {
+		downloaded = true;
+		this.localPath = localPath;
+	}
+
+	void discardCache() {
+		downloaded = false;
+	}
+
+	void harvest(DownloadableTensorFlowVersion other) {
+		if(!cuda.isPresent() && other.cuda.isPresent()) {
+			cuda = other.cuda;
+		}
+		if(!cudnn.isPresent() && other.cudnn.isPresent()) {
+			cudnn = other.cudnn;
+		}
+		if(url == null) url = other.url;
+		if(localPath == null) localPath = other.localPath;
+		downloaded = other.downloaded;
+	}
+
+	@Override
+	public boolean equals(final Object obj) {
+		if (!(obj.getClass().equals(this.getClass()))) return false;
+		final DownloadableTensorFlowVersion o = (DownloadableTensorFlowVersion) obj;
+		return super.equals(o) && Objects.equals(platform, o.platform);
+	}
+}

--- a/src/main/java/net/imagej/tensorflow/ui/TensorFlowInstallationHandler.java
+++ b/src/main/java/net/imagej/tensorflow/ui/TensorFlowInstallationHandler.java
@@ -1,0 +1,151 @@
+/*-
+ * #%L
+ * ImageJ/TensorFlow integration.
+ * %%
+ * Copyright (C) 2019 Board of Regents of the University of
+ * Wisconsin-Madison and Google, Inc.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.tensorflow.ui;
+
+import net.imagej.tensorflow.util.TensorFlowUtil;
+import net.imagej.tensorflow.util.UnpackUtil;
+import org.scijava.app.AppService;
+import org.scijava.log.LogService;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+
+/**
+ * This class handles instances of {@link DownloadableTensorFlowVersion}.
+ * It is responsible for downloading, caching, unpacking, and installing them.
+ *
+ * @author Deborah Schmidt
+ * @author Benjamin Wilhelm
+ */
+class TensorFlowInstallationHandler {
+
+	private final AppService appService;
+
+	private final LogService logService;
+
+	private static final String DOWNLOADDIR = "downloads/";
+
+	TensorFlowInstallationHandler(final AppService appService, final LogService logService) {
+		this.appService = appService;
+		this.logService = logService;
+	}
+
+	/**
+	 * Checks for a specific version whether it is downloaded and installed.
+	 * @param version the version which will be checked
+	 */
+	void updateCacheStatus(final DownloadableTensorFlowVersion version) {
+		if(version.getURL() == null) return;
+		if (version.getURL().getProtocol().equalsIgnoreCase("file")) {
+			version.setCached(version.getURL().getFile());
+		} else {
+			String path = getDownloadDir() + getNameFromURL(version.getURL());
+			if (new File(path).exists()) {
+				version.setCached(path);
+			}
+		}
+	}
+
+	private String getNameFromURL(URL url) {
+		String[] parts = url.getPath().split("/");
+		if(parts.length > 0) return parts[parts.length - 1];
+		else return null;
+	}
+
+	/**
+	 * Activates a specific TensorFlow library which will then be used after restarting the application.
+	 * @param version the version being activated
+	 * @throws IOException thrown in case downloading the version failed or the version could not be unpacked
+	 */
+	void activateVersion(DownloadableTensorFlowVersion version) throws IOException {
+		if (!version.isCached()) {
+			downloadVersion(version.getURL());
+		}
+		updateCacheStatus(version);
+		if (!version.isActive()) {
+			TensorFlowUtil.removeNativeLibraries(getRoot(), logService);
+			installVersion(version);
+		}
+	}
+
+	private void downloadVersion(URL url) throws IOException {
+		createDownloadDir();
+		String filename = url.getFile().substring(url.getFile().lastIndexOf("/") + 1);
+		String localFile = getDownloadDir() + filename;
+		logService.info("Downloading " + url + " to " + localFile);
+		InputStream in = url.openStream();
+		Files.copy(in, Paths.get(localFile), StandardCopyOption.REPLACE_EXISTING);
+	}
+
+	private void createDownloadDir() {
+		File downloadDir = new File(getDownloadDir());
+		if (!downloadDir.exists()) {
+			downloadDir.mkdirs();
+		}
+	}
+
+	private void installVersion(DownloadableTensorFlowVersion version) throws IOException {
+
+		logService.info("Installing " + version);
+
+		String outputDir = TensorFlowUtil.getUpdateLibDir(getRoot()) + version.getPlatform() + File.separator;
+
+		if (version.getLocalPath().contains(".zip")) {
+			UnpackUtil.unZip(version.getLocalPath(), outputDir, logService);
+			TensorFlowUtil.writeNativeVersionFile(getRoot(), version.getPlatform(), version);
+		} else if (version.getLocalPath().endsWith(".tar.gz")) {
+			String symLinkOutputDir = TensorFlowUtil.getLibDir(getRoot()) + version.getPlatform() + File.separator;;
+			UnpackUtil.unGZip(version.getLocalPath(), outputDir, symLinkOutputDir, logService);
+			TensorFlowUtil.writeNativeVersionFile(getRoot(), version.getPlatform(), version);
+		}
+
+		if (version.getLocalPath().endsWith(".jar")) {
+			// using default JAR version. nothing to do.
+			logService.info("Using default JAR TensorFlow version.");
+		}
+
+		TensorFlowUtil.getCrashFile(getRoot()).delete();
+	}
+
+	private String getRoot() {
+		return appService.getApp().getBaseDirectory().getAbsolutePath();
+	}
+
+	private String getDownloadDir() {
+		return appService.getApp().getBaseDirectory().getAbsolutePath() + File.separator + DOWNLOADDIR;
+	}
+
+}

--- a/src/main/java/net/imagej/tensorflow/ui/TensorFlowLibraryManagementCommand.java
+++ b/src/main/java/net/imagej/tensorflow/ui/TensorFlowLibraryManagementCommand.java
@@ -1,0 +1,130 @@
+/*-
+ * #%L
+ * ImageJ/TensorFlow integration.
+ * %%
+ * Copyright (C) 2019 Board of Regents of the University of
+ * Wisconsin-Madison and Google, Inc.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.tensorflow.ui;
+
+import net.imagej.ImageJ;
+import net.imagej.tensorflow.TensorFlowService;
+import net.imagej.tensorflow.TensorFlowVersion;
+import net.imagej.tensorflow.util.TensorFlowUtil;
+import net.imagej.updater.util.UpdaterUtil;
+import org.scijava.app.AppService;
+import org.scijava.command.Command;
+import org.scijava.log.LogService;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+import java.awt.*;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This command provides an interface for activating a specific Java TensorFlow version.
+ * The user can choose between the version included via maven and archived native library versions
+ * which can be downloaded from the Google servers.
+ *
+ * @author Deborah Schmidt
+ * @author Benjamin Wilhelm
+ */
+@Plugin(type = Command.class, menuPath = "Edit>Options>TensorFlow...")
+public class TensorFlowLibraryManagementCommand implements Command {
+
+	@Parameter
+	private TensorFlowService tensorFlowService;
+
+	@Parameter
+	private AppService appService;
+
+	@Parameter
+	private LogService logService;
+
+	DownloadableTensorFlowVersion currentVersion;
+	List<DownloadableTensorFlowVersion> availableVersions = new ArrayList<>();
+
+	String platform = UpdaterUtil.getPlatform();
+
+	private TensorFlowInstallationHandler installationHandler;
+
+	@Override
+	public void run() {
+		tensorFlowService.loadLibrary();
+		installationHandler = new TensorFlowInstallationHandler(appService, logService);
+		final TensorFlowLibraryManagementFrame frame = new TensorFlowLibraryManagementFrame(tensorFlowService, installationHandler);
+		frame.init();
+		initAvailableVersions();
+		frame.updateChoices(availableVersions);
+		frame.pack();
+		frame.setLocationRelativeTo(null);
+		frame.setMinimumSize(new Dimension(0, 200));
+		frame.setVisible(true);
+
+	}
+
+	private void initAvailableVersions() {
+		initCurrentVersion();
+		if(currentVersion != null) addAvailableVersion(currentVersion);
+		addAvailableVersion(getTensorFlowJARVersion());
+		AvailableTensorFlowVersions.get().forEach(version -> addAvailableVersion(version));
+	}
+
+	private void initCurrentVersion() {
+		TensorFlowVersion current = tensorFlowService.getTensorFlowVersion();
+		if(current != null) {
+			currentVersion = new DownloadableTensorFlowVersion(current);
+			currentVersion.setPlatform(platform);
+			currentVersion.setActive(true);
+		}
+	}
+
+	private DownloadableTensorFlowVersion getTensorFlowJARVersion() {
+		DownloadableTensorFlowVersion version = new DownloadableTensorFlowVersion(TensorFlowUtil.versionFromClassPathJAR());
+		version.setPlatform(platform);
+		version.setURL(TensorFlowUtil.getTensorFlowJAR());
+		return version;
+	}
+
+	private void addAvailableVersion(DownloadableTensorFlowVersion version) {
+		if(!version.getPlatform().equals(platform)) return;
+		installationHandler.updateCacheStatus(version);
+		for (DownloadableTensorFlowVersion other : availableVersions) {
+			if (other.equals(version)) {
+				other.harvest(version);
+				return;
+			}
+		}
+		availableVersions.add(version);
+	}
+
+	public static void main(String... args) {
+		ImageJ ij = new ImageJ();
+		ij.ui().showUI();
+		ij.command().run(TensorFlowLibraryManagementCommand.class, true);
+	}
+}

--- a/src/main/java/net/imagej/tensorflow/ui/TensorFlowLibraryManagementCommand.java
+++ b/src/main/java/net/imagej/tensorflow/ui/TensorFlowLibraryManagementCommand.java
@@ -35,6 +35,7 @@ import net.imagej.tensorflow.TensorFlowService;
 import net.imagej.tensorflow.TensorFlowVersion;
 import net.imagej.tensorflow.util.TensorFlowUtil;
 import net.imagej.updater.util.UpdaterUtil;
+import org.scijava.Context;
 import org.scijava.app.AppService;
 import org.scijava.command.Command;
 import org.scijava.log.LogService;
@@ -65,6 +66,9 @@ public class TensorFlowLibraryManagementCommand implements Command {
 	@Parameter
 	private LogService logService;
 
+	@Parameter
+	private Context context;
+
 	DownloadableTensorFlowVersion currentVersion;
 	List<DownloadableTensorFlowVersion> availableVersions = new ArrayList<>();
 
@@ -75,7 +79,8 @@ public class TensorFlowLibraryManagementCommand implements Command {
 	@Override
 	public void run() {
 		tensorFlowService.loadLibrary();
-		installationHandler = new TensorFlowInstallationHandler(appService, logService);
+		installationHandler = new TensorFlowInstallationHandler();
+		context.inject(installationHandler);
 		final TensorFlowLibraryManagementFrame frame = new TensorFlowLibraryManagementFrame(tensorFlowService, installationHandler);
 		frame.init();
 		initAvailableVersions();

--- a/src/main/java/net/imagej/tensorflow/ui/TensorFlowLibraryManagementFrame.java
+++ b/src/main/java/net/imagej/tensorflow/ui/TensorFlowLibraryManagementFrame.java
@@ -1,0 +1,251 @@
+/*-
+ * #%L
+ * ImageJ/TensorFlow integration.
+ * %%
+ * Copyright (C) 2019 Board of Regents of the University of
+ * Wisconsin-Madison and Google, Inc.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.tensorflow.ui;
+
+import net.imagej.tensorflow.TensorFlowService;
+import net.miginfocom.swing.MigLayout;
+
+import javax.swing.*;
+import java.awt.*;
+import java.io.IOException;
+import java.util.*;
+import java.util.List;
+
+/**
+ * The UI part of the {@link TensorFlowLibraryManagementCommand}
+ *
+ * @author Deborah Schmidt
+ * @author Benjamin Wilhelm
+ */
+class TensorFlowLibraryManagementFrame extends JFrame {
+
+	private static final long serialVersionUID = 1L;
+
+	private static final Color LIST_BACKGROUND_COLOR = new Color(250,250,250);
+	private static final String NOFILTER = "-";
+
+	private TensorFlowService tensorFlowService;
+	private TensorFlowInstallationHandler installationHandler;
+
+	private JComboBox<String> gpuChoiceBox;
+	private JComboBox<String> cudaChoiceBox;
+	private JComboBox<String> tfChoiceBox;
+	private JPanel installPanel;
+	private JTextArea status;
+
+	private List<DownloadableTensorFlowVersion> availableVersions = new ArrayList<>();
+	private List<JRadioButton> buttons = new ArrayList<>();
+
+	TensorFlowLibraryManagementFrame(final TensorFlowService tensorFlowInstallationService, final TensorFlowInstallationHandler installationHandler) {
+		super("TensorFlow library version management");
+		this.tensorFlowService = tensorFlowInstallationService;
+		this.installationHandler = installationHandler;
+	}
+
+	public void init() {
+		JPanel panel = new JPanel();
+		panel.setLayout(new MigLayout("height 400, wmax 600"));
+		panel.add(new JLabel("Please select the TensorFlow version you would like to install."), "wrap");
+		panel.add(createFilterPanel(), "wrap, span, align right");
+		panel.add(createInstallPanel(), "wrap, span, grow");
+		panel.add(createStatus(), "span, grow");
+		setContentPane(panel);
+	}
+
+	private Component createFilterPanel() {
+		gpuChoiceBox = new JComboBox<>();
+		gpuChoiceBox.addItem(NOFILTER);
+		gpuChoiceBox.addItem("GPU");
+		gpuChoiceBox.addItem("CPU");
+		gpuChoiceBox.addActionListener((e) -> updateFilter());
+		cudaChoiceBox = new JComboBox<>();
+		cudaChoiceBox.addActionListener((e) -> updateFilter());
+		tfChoiceBox = new JComboBox<>();
+		tfChoiceBox.addActionListener((e) -> updateFilter());
+		JPanel panel = new JPanel();
+		panel.setLayout(new MigLayout());
+		panel.add(makeLabel("Filter by.."));
+		panel.add(makeLabel("Mode: "));
+		panel.add(gpuChoiceBox);
+		panel.add(makeLabel("CUDA: "));
+		panel.add(cudaChoiceBox);
+		panel.add(makeLabel("TensorFlow: "));
+		panel.add(tfChoiceBox);
+		return panel;
+	}
+
+	private Component createStatus() {
+		status = new JTextArea();
+		status.setBorder(BorderFactory.createEmptyBorder());
+		status.setEditable(false);
+		status.setWrapStyleWord(true);
+		status.setLineWrap(true);
+		status.setOpaque(false);
+		return status;
+	}
+
+	private void updateFilter() {
+		installPanel.removeAll();
+		buttons.forEach(btn -> {
+			if(filter("", gpuChoiceBox, btn)) return;
+			if(filter("CUDA ", cudaChoiceBox, btn)) return;
+			if(filter("TF ", tfChoiceBox, btn)) return;
+			installPanel.add(btn);
+		});
+		installPanel.revalidate();
+		installPanel.repaint();
+	}
+
+	private boolean filter(String title, JComboBox<String> choiceBox, JRadioButton btn) {
+		if(choiceBox.getSelectedItem().toString().equals(NOFILTER)) return false;
+		return !btn.getText().contains(title + choiceBox.getSelectedItem().toString());
+	}
+
+	private JLabel makeLabel(String s) {
+		JLabel label = new JLabel(s);
+		label.setHorizontalAlignment(SwingConstants.RIGHT);
+		label.setHorizontalTextPosition(SwingConstants.RIGHT);
+		return label;
+	}
+
+	private Component createInstallPanel() {
+		installPanel = new JPanel(new MigLayout("flowy"));
+		JScrollPane scroll = new JScrollPane(installPanel);
+		scroll.setBorder(BorderFactory.createEmptyBorder());
+		installPanel.setBackground(LIST_BACKGROUND_COLOR);
+		return scroll;
+	}
+
+	void updateChoices(List<DownloadableTensorFlowVersion> availableVersions) {
+		availableVersions.sort(Comparator.comparing(DownloadableTensorFlowVersion::getComparableTFVersion).reversed());
+		this.availableVersions = availableVersions;
+		updateCUDAChoices();
+		updateTFChoices();
+		ButtonGroup versionGroup = new ButtonGroup();
+		installPanel.removeAll();
+		for( DownloadableTensorFlowVersion version : availableVersions) {
+			JRadioButton btn = new JRadioButton(version.toString());
+			btn.setToolTipText(version.getOriginDescription());
+			btn.setSelected(version.isActive());
+			btn.setOpaque(false);
+			versionGroup.add(btn);
+			buttons.add(btn);
+			btn.addActionListener(e -> {
+				if(btn.isSelected()) {
+					new Thread(() -> activateVersion(version)).start();
+				}
+			});
+		}
+		updateFilter();
+		updateStatus();
+	}
+
+	private void updateStatus() {
+		status.setText(tensorFlowService.getStatus().getInfo());
+		if(!tensorFlowService.getStatus().isLoaded()) {
+			status.setForeground(Color.red);
+		} else {
+			status.setForeground(Color.black);
+		}
+	}
+
+	private void activateVersion(DownloadableTensorFlowVersion version) {
+		if(version.isActive()) {
+			System.out.println("[WARNING] Cannot activate version, already active: " + version);
+			return;
+		}
+		showWaitMessage();
+		try {
+			installationHandler.activateVersion(version);
+		} catch (IOException e) {
+			e.printStackTrace();
+			Object[] options = {"Yes",
+					"No",
+					"Cancel"};
+			int choice = JOptionPane.showOptionDialog(this,
+					"Error while unpacking library file " + version.getLocalPath() + ".\nShould it be downloaded again?",
+					"Unpacking library error",
+					JOptionPane.YES_NO_CANCEL_OPTION,
+					JOptionPane.QUESTION_MESSAGE,
+					null,
+					options,
+					options[0]);
+			if(choice == 0) {
+				version.discardCache();
+				try {
+					installationHandler.activateVersion(version);
+				} catch (IOException e1) {
+					e1.printStackTrace();
+				}
+			} else {
+				status.setText("Installation failed: " + e.getClass().getName() + ": " + e.getMessage());
+				return;
+			}
+		}
+		status.setText("");
+		JOptionPane.showMessageDialog(null,
+				"Installed selected TensorFlow version. Please restart Fiji to load it.",
+				"Please restart",
+				JOptionPane.PLAIN_MESSAGE);
+		dispose();
+	}
+
+	private void showWaitMessage() {
+		status.setForeground(Color.black);
+		status.setText("Please wait..");
+	}
+
+	private void updateCUDAChoices() {
+		Set<String> choices = new LinkedHashSet<>();
+		for(DownloadableTensorFlowVersion version :availableVersions) {
+			if(version.getCompatibleCUDA().isPresent())
+				choices.add(version.getCompatibleCUDA().get());
+		}
+		cudaChoiceBox.removeAllItems();
+		cudaChoiceBox.addItem(NOFILTER);
+		for(String choice : choices) {
+			cudaChoiceBox.addItem(choice);
+		}
+	}
+
+	private void updateTFChoices() {
+		Set<String> choices = new LinkedHashSet<>();
+		for(DownloadableTensorFlowVersion version :availableVersions) {
+			if(version.getVersionNumber() != null) choices.add(version.getVersionNumber());
+		}
+		tfChoiceBox.removeAllItems();
+		tfChoiceBox.addItem(NOFILTER);
+		for(String choice : choices) {
+			tfChoiceBox.addItem(choice);
+		}
+	}
+
+}

--- a/src/main/java/net/imagej/tensorflow/util/TensorFlowUtil.java
+++ b/src/main/java/net/imagej/tensorflow/util/TensorFlowUtil.java
@@ -1,0 +1,231 @@
+/*-
+ * #%L
+ * ImageJ/TensorFlow integration.
+ * %%
+ * Copyright (C) 2019 Board of Regents of the University of
+ * Wisconsin-Madison and Google, Inc.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.tensorflow.util;
+
+import net.imagej.tensorflow.TensorFlowVersion;
+import net.imagej.updater.util.UpdaterUtil;
+import org.scijava.log.Logger;
+import org.tensorflow.TensorFlow;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.net.JarURLConnection;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Utility methods for dealing with the Java TensorFlow library
+ *
+ * @author Deborah Schmidt
+ * @author Benjamin Wilhelm
+ */
+public final class TensorFlowUtil {
+
+	private static final String TFVERSIONFILE = ".tensorflowversion";
+	private static final String CRASHFILE = ".crashed";
+	private static final String LIBDIR = "lib";
+	private static final String UPDATEDIR = "update";
+
+	private static final String PLATFORM = UpdaterUtil.getPlatform();
+
+	private static Pattern jarVersionPattern = Pattern.compile("(?<=(libtensorflow-)).*(?=(.jar))");
+
+	private TensorFlowUtil(){}
+
+	/**
+	 * @param jar the JAR file of the TensorFlow library
+	 * @return the version which will be loaded by the JAR file
+	 */
+	public static TensorFlowVersion getTensorFlowJARVersion(URL jar) {
+		Matcher matcher = jarVersionPattern.matcher(jar.getPath());
+		if(matcher.find()) {
+			// guess GPU support by looking for tensorflow_jni_gpu in the class path
+			boolean supportsGPU = false;
+			ClassLoader cl = ClassLoader.getSystemClassLoader();
+			for(URL url: ((URLClassLoader)cl).getURLs()){
+				if(url.getFile().contains("libtensorflow_jni_gpu")) {
+					supportsGPU = true;
+					break;
+				}
+			}
+			return new TensorFlowVersion(matcher.group(), supportsGPU, null, null);
+		}
+		return null;
+	}
+
+	/**
+	 * @return The TensorFlow version included in the class path which will be loaded by default if no other native library is loaded beforehand.
+	 */
+	public static TensorFlowVersion versionFromClassPathJAR() {
+		return getTensorFlowJARVersion(getTensorFlowJAR());
+	}
+
+	/**
+	 * @return The JAR file URL shipping TensorFlow in Java
+	 */
+	public static URL getTensorFlowJAR() {
+		URL resource = TensorFlow.class.getResource("TensorFlow.class");
+		JarURLConnection connection = null;
+		try {
+			connection = (JarURLConnection) resource.openConnection();
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+		return connection.getJarFileURL();
+	}
+
+	/**
+	 * Deletes all TensorFlow native library files in {@link #getLibDir(String)}.
+	 * @param root the root path of ImageJ
+	 * @param logger
+	 */
+	public static void removeNativeLibraries(String root, Logger logger)  {
+		final File folder = new File(TensorFlowUtil.getLibDir(root), PLATFORM);
+		if(!folder.exists()) {
+			return;
+		}
+		final File[] listOfFiles = folder.listFiles();
+		for (File file : listOfFiles) {
+			if (file.getName().toLowerCase().contains("tensorflow")) {
+				logger.info("Deleting " + file);
+				file.delete();
+			}
+		}
+	}
+
+	/**
+	 * Reading the content of the {@link #TFVERSIONFILE} indicating which native version of TensorFlow is installed
+	 * @param root the root path of ImageJ
+	 * @return the current TensorFlow version installed in ImageJ/lib
+	 * @throws IOException in case the util file containing the native version number cannot be read (must not mean there is no usable native version)
+	 */
+	public static TensorFlowVersion readNativeVersionFile(String root) throws IOException {
+		if(getNativeVersionFile(root).exists()) {
+			Path path = getNativeVersionFile(root).toPath();
+			final String versionstr = new String(Files.readAllBytes(path));
+			final String[] parts = versionstr.split(",");
+			if(parts.length >= 3) {
+				String version = parts[1];
+				boolean gpuSupport = parts[2].toLowerCase().equals("gpu");
+				if(parts.length == 3) {
+					return new TensorFlowVersion(version, gpuSupport, null, null);
+				}
+				if(parts.length == 5) {
+					String cuda = parts[3];
+					String cudnn = parts[4];
+					return new TensorFlowVersion(version, gpuSupport, cuda, cudnn);
+				}
+			} else {
+				throw new IOException("Content of " + path + " does not match expected format");
+			}
+		}
+		// unknown version origin
+		return new TensorFlowVersion(TensorFlow.version(), null, null, null);
+	}
+
+	/**
+	 * Writing the content of the {@link #TFVERSIONFILE} indicating which native version of TensorFlow is installed
+	 * @param root the root path of ImageJ
+	 * @param platform the platform of the user (e.g. linux64, win64, macosx)
+	 * @param version the installed TensorFlow version
+	 */
+	public static void writeNativeVersionFile(String root, String platform, TensorFlowVersion version) {
+		// create content
+		StringBuilder content = new StringBuilder();
+		content.append(platform);
+		content.append(",");
+		content.append(version.getVersionNumber());
+		content.append(",");
+		if(version.usesGPU().isPresent()) {
+			content.append(version.usesGPU().get() ? "GPU" : "CPU");
+		} else {
+			content.append("?");
+		}
+		if(version.getCompatibleCuDNN().isPresent() || version.getCompatibleCUDA().isPresent()) {
+			if(version.getCompatibleCUDA().isPresent()) {
+				content.append(",");
+				content.append(version.getCompatibleCUDA().get());
+			} else {
+				content.append("?");
+			}
+			if(version.getCompatibleCuDNN().isPresent()) {
+				content.append(",");
+				content.append(version.getCompatibleCuDNN().get());
+			} else {
+				content.append("?");
+			}
+		}
+		//write content to file
+		try (BufferedWriter writer = new BufferedWriter(new FileWriter(getNativeVersionFile(root)))) {
+			writer.write(content.toString());
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+	}
+
+	/**
+	 * @param root the root path of ImageJ
+	 * @return the crash File location indication if loading TensorFlow resulted in a JVM crash
+	 */
+	public static File getCrashFile(String root) {
+		return new File(getLibDir(root) + PLATFORM + File.separator + CRASHFILE);
+	}
+
+	/**
+	 * @param root the root path of ImageJ
+	 * @return the file indication which native TensorFlow version is currently installed
+	 */
+	public static File getNativeVersionFile(String root) {
+		return new File(getLibDir(root) + PLATFORM + File.separator + TFVERSIONFILE);
+	}
+
+	/**
+	 * @param root the root path of ImageJ
+	 * @return the directory where native libraries can be placed so that they are loadable from Java
+	 */
+	public static String getLibDir(String root) {
+		return root + File.separator + LIBDIR + File.separator;
+	}
+
+	/**
+	 * @param root the root path of ImageJ
+	 * @return the directory where native libraries can be placed so that the updater will move them into {@link #getLibDir(String)}
+	 */
+	public static String getUpdateLibDir(String root) {
+		return root + File.separator + UPDATEDIR + File.separator + LIBDIR + File.separator;
+	}
+}

--- a/src/main/java/net/imagej/tensorflow/util/UnpackUtil.java
+++ b/src/main/java/net/imagej/tensorflow/util/UnpackUtil.java
@@ -1,0 +1,149 @@
+/*-
+ * #%L
+ * ImageJ/TensorFlow integration.
+ * %%
+ * Copyright (C) 2019 Board of Regents of the University of
+ * Wisconsin-Madison and Google, Inc.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.tensorflow.util;
+
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.scijava.log.Logger;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+/**
+ * Utility class for unpacking archives
+ * TODO: generalize and move it to a place where others can use it as well
+ *
+ * @author Deborah schmidt
+ */
+public final class UnpackUtil {
+
+	private UnpackUtil(){}
+
+	public static void unGZip(String tarGzFile, String outputDir, String symLinkOutputDir, Logger logger) throws IOException {
+		logger.info("Unpacking " + tarGzFile + " to " + outputDir);
+		File folder = new File(outputDir);
+		if (!folder.exists()) {
+			folder.mkdirs();
+		}
+
+		String tarFileName = tarGzFile.replace(".gz", "");
+		FileInputStream instream = new FileInputStream(tarGzFile);
+		GZIPInputStream ginstream = new GZIPInputStream(instream);
+		FileOutputStream outstream = new FileOutputStream(tarFileName);
+		byte[] buf = new byte[1024];
+		int len;
+		while ((len = ginstream.read(buf)) > 0) {
+			outstream.write(buf, 0, len);
+		}
+		ginstream.close();
+		outstream.close();
+		TarArchiveInputStream myTarFile = new TarArchiveInputStream(new FileInputStream(tarFileName));
+		TarArchiveEntry entry;
+		while ((entry = myTarFile.getNextTarEntry()) != null) {
+			if (entry.isSymbolicLink() || entry.isLink()) {
+				Path source = Paths.get(outputDir + entry.getName());
+				Path target = Paths.get(symLinkOutputDir + entry.getLinkName());
+				if (entry.isSymbolicLink()) {
+					logger.info("Creating symbolic link: " + source + " -> " + target);
+					Files.createSymbolicLink(source, target);
+				} else {
+					logger.info("Creating link: " + source + " -> " + target);
+					Files.createLink(source, target);
+				}
+			} else {
+				File output = new File(folder + "/" + entry.getName());
+				if (!output.getParentFile().exists()) {
+					output.getParentFile().mkdirs();
+				}
+				if (output.isDirectory())
+					continue;
+				byte[] content = new byte[(int) entry.getSize()];
+				int offset = 0;
+				myTarFile.read(content, offset, content.length - offset);
+				logger.info("Writing " + output);
+				FileOutputStream outputStream = new FileOutputStream(output);
+				outputStream.write(content);
+				outputStream.close();
+			}
+		}
+		myTarFile.close();
+		File tarFile = new File(tarFileName);
+		tarFile.delete();
+	}
+
+	public static void unZip(String zipFile, String outputFolder, Logger logger) throws IOException {
+
+		logger.info("Unpacking " + zipFile + " to " + outputFolder);
+
+		byte[] buffer = new byte[1024];
+
+		File folder = new File(outputFolder);
+		if (!folder.exists()) {
+			folder.mkdirs();
+		}
+
+		ZipInputStream zis = new ZipInputStream(new FileInputStream(zipFile));
+		ZipEntry ze = zis.getNextEntry();
+
+		while (ze != null) {
+
+			String fileName = ze.getName().replace("Fiji.app/", "");
+			File newFile = new File(outputFolder + File.separator + fileName);
+
+			logger.info("Writing " + newFile.getAbsoluteFile());
+
+			new File(newFile.getParent()).mkdirs();
+
+			FileOutputStream fos = new FileOutputStream(newFile);
+
+			int len;
+			while ((len = zis.read(buffer)) > 0) {
+				fos.write(buffer, 0, len);
+			}
+
+			fos.close();
+			ze = zis.getNextEntry();
+
+		}
+
+		zis.closeEntry();
+		zis.close();
+	}
+
+}

--- a/src/test/java/net/imagej/tensorflow/VersionBuilderTest.java
+++ b/src/test/java/net/imagej/tensorflow/VersionBuilderTest.java
@@ -1,0 +1,18 @@
+package net.imagej.tensorflow;
+
+import net.imagej.tensorflow.util.TensorFlowUtil;
+import org.junit.Test;
+import org.tensorflow.TensorFlow;
+
+import java.net.URL;
+
+import static org.junit.Assert.assertEquals;
+
+public class VersionBuilderTest {
+	@Test
+	public void testJARVersion() {
+		URL source = TensorFlow.class.getResource("TensorFlow.class");
+		TensorFlowVersion version = TensorFlowUtil.getTensorFlowJARVersion(source);
+		assertEquals(TensorFlow.version(), version.getVersionNumber());
+	}
+}

--- a/src/test/java/net/imagej/tensorflow/demo/LabelImageTest.java
+++ b/src/test/java/net/imagej/tensorflow/demo/LabelImageTest.java
@@ -1,0 +1,28 @@
+package net.imagej.tensorflow.demo;
+
+import net.imagej.Dataset;
+import net.imagej.ImageJ;
+import net.imagej.axis.Axes;
+import net.imagej.axis.AxisType;
+import net.imglib2.type.numeric.real.FloatType;
+import org.junit.Test;
+import org.scijava.command.CommandModule;
+
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.Assert.assertNotNull;
+
+public class LabelImageTest {
+
+	@Test
+	public void runLabelImageCommand() throws ExecutionException, InterruptedException {
+		final ImageJ ij = new ImageJ();
+		Dataset img = ij.dataset().create(new FloatType(), new long[]{10, 10, 3}, "", new AxisType[]{Axes.X, Axes.Y});
+		CommandModule module = ij.command().run(LabelImage.class, false, "inputImage", img).get();
+		assertNotNull(module);
+		String labels = (String) module.getOutput("outputLabels");
+		assertNotNull(labels);
+		System.out.println(labels);
+	}
+
+}

--- a/src/test/java/net/imagej/tensorflow/ui/AvailableTensorFlowVersionsTest.java
+++ b/src/test/java/net/imagej/tensorflow/ui/AvailableTensorFlowVersionsTest.java
@@ -1,0 +1,25 @@
+package net.imagej.tensorflow.ui;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class AvailableTensorFlowVersionsTest {
+
+	@Test
+	public void testURLs() throws IOException {
+		List<DownloadableTensorFlowVersion> versions = AvailableTensorFlowVersions.get();
+		for (DownloadableTensorFlowVersion version : versions) {
+			System.out.println("Testing " + version.getURL());
+			HttpURLConnection huc =  (HttpURLConnection)  version.getURL().openConnection();
+			huc.setRequestMethod("HEAD");
+			huc.connect();
+			assertEquals(HttpURLConnection.HTTP_OK, huc.getResponseCode());
+		}
+	}
+
+}

--- a/src/test/java/net/imagej/tensorflow/ui/TensorFlowVersionTest.java
+++ b/src/test/java/net/imagej/tensorflow/ui/TensorFlowVersionTest.java
@@ -1,0 +1,31 @@
+package net.imagej.tensorflow.ui;
+
+import net.imagej.tensorflow.TensorFlowVersion;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class TensorFlowVersionTest {
+
+	@Test
+	public void compareVersions() {
+		TensorFlowVersion v1 = new TensorFlowVersion("1.4.0", true, null, null);
+		TensorFlowVersion v2 = new TensorFlowVersion("1.4.0", true, null, null);
+		assertEquals(v1, v2);
+
+		v1 = new TensorFlowVersion("1.4.0", true, null, null);
+		v2 = new TensorFlowVersion("1.4.0", false, null, null);
+		assertNotEquals(v1, v2);
+
+		v1 = new TensorFlowVersion("1.4.0", false, null, null);
+		v2 = new TensorFlowVersion("1.4.0", false, "x.x", "y.y");
+		assertEquals(v1, v2);
+
+		DownloadableTensorFlowVersion v3 = new DownloadableTensorFlowVersion("1.4.0", false);
+		assertNotEquals(v3, v1);
+		assertNotEquals(v1, v3);
+
+	}
+
+}


### PR DESCRIPTION
This PR adds the possibility to switch between TensorFlow libraries.
* `TensorFlowLibraryManagementCommand` contains hardcoded links to available JNI packages
* `TensorFlowLibraryManagementFrame` is providing the interface
* if the user chooses a version
	1) the package is downloaded to `Fiji.app/downloads` (in case it is not already there)
	2) the package is unpacked to `Fiji.app/lib/PLATFORM/`
	3) the user is prompted to restart Fiji
* hovering over a list item will display the source file of the version
* the `TensorFlowService` has additional methods to be used by Commands which want to know about the state of the current TF installation

![image](https://user-images.githubusercontent.com/708121/60332449-22889a80-9997-11e9-8ff6-606e41116eeb.png)

It is not yet tested on Windows. It contains swing ui code. I could also move this part to `imagej-ui-swing`.