### PR TITLE
Adding CachedModelBundle..

### DIFF
--- a/src/main/java/net/imagej/tensorflow/CachedModelBundle.java
+++ b/src/main/java/net/imagej/tensorflow/CachedModelBundle.java
@@ -1,0 +1,60 @@
+/*-
+ * #%L
+ * ImageJ/TensorFlow integration.
+ * %%
+ * Copyright (C) 2019 Board of Regents of the University of
+ * Wisconsin-Madison and Google, Inc.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.tensorflow;
+
+import org.tensorflow.SavedModelBundle;
+
+/**
+ * A wrapper for {@link SavedModelBundle} remembering if it got closed.
+ * @author Deborah Schmidt
+ */
+public class CachedModelBundle implements AutoCloseable {
+	private SavedModelBundle model;
+	private boolean closed = false;
+
+	public CachedModelBundle(String path, String[] tags) {
+		this.model = SavedModelBundle.load(path, tags);
+	}
+
+	public SavedModelBundle model() {
+		return model;
+	}
+
+	@Override
+	public void close() {
+		closed = true;
+		model.close();
+	}
+
+	public boolean isClosed() {
+		return closed;
+	}
+}

--- a/src/main/java/net/imagej/tensorflow/TensorFlowService.java
+++ b/src/main/java/net/imagej/tensorflow/TensorFlowService.java
@@ -58,9 +58,29 @@ public interface TensorFlowService extends ImageJService {
 	 * @return The extracted TensorFlow {@link SavedModelBundle} object.
 	 * @throws IOException If something goes wrong reading or unpacking the
 	 *           archive.
+	 * Deprecated - use {@link #loadCachedModel(Location, String, String...)} instead.
 	 */
+	@Deprecated
 	SavedModelBundle loadModel(Location source, String modelName, String... tags)
 		throws IOException;
+
+	/**
+	 * Extracts a persisted model from the given location.
+	 * Returns it from cache in case it was already loaded.
+	 *
+	 * @param source The location of the model, which must be structured as a ZIP
+	 *          archive.
+	 * @param modelName The name of the model by which the source should be
+	 *          unpacked and cached as needed.
+	 * @param tags Optional list of tags passed to
+	 *          {@link SavedModelBundle#load(String, String...)}.
+	 * @return The extracted TensorFlow {@link SavedModelBundle} object
+	 *           wrapped by a {@link CachedModelBundle}.
+	 * @throws IOException If something goes wrong reading or unpacking the
+	 *           archive.
+	 */
+	CachedModelBundle loadCachedModel(Location source, String modelName, String... tags)
+			throws IOException;
 
 	/**
 	 * Extracts a graph from the given location.


### PR DESCRIPTION
.. to keep track if a model cached in memory is still open. (#23)

- this restores backwards compatibility after the changes made in 14f6da185d8c06aac97934c3f2079d8503b98b2f
- `CachedModelBundle` wraps `SavedModelBundle`, keeping track if it gets closed
- in case it got closed, the model is not loaded from memory but reloaded from disk
- `TensorFlowService::loadModel` is deprecated and does not cache the model as in the latest release, one should use `TensorFlowService::loadCachedModel` and then call `model.model()` to access the actual `SavedModelBundle`