### PR TITLE
Add miglayout-swing and pin to version 5.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,7 @@ Wisconsin-Madison and Google, Inc.</license.copyrightOwners>
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>deploy-to-scijava</releaseProfiles>
 		<apache-commons-compress.version>1.18</apache-commons-compress.version>
+		<miglayout-swing.version>5.2</miglayout-swing.version>
 	</properties>
 
 	<repositories>
@@ -131,6 +132,12 @@ Wisconsin-Madison and Google, Inc.</license.copyrightOwners>
 		<dependency>
 			<groupId>net.imagej</groupId>
 			<artifactId>imagej</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>com.miglayout</groupId>
+					<artifactId>miglayout</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.tensorflow</groupId>
@@ -150,6 +157,13 @@ Wisconsin-Madison and Google, Inc.</license.copyrightOwners>
 			<artifactId>commons-compress</artifactId>
 			<version>${apache-commons-compress.version}</version>
 		</dependency>
+
+		<dependency>
+			<groupId>com.miglayout</groupId>
+			<artifactId>miglayout-swing</artifactId>
+			<version>${miglayout-swing.version}</version>
+		</dependency>
+
 		<!-- Test dependencies -->
 		<dependency>
 			<groupId>junit</groupId>


### PR DESCRIPTION
This is used in TensorFlowLibraryManagementFrame, but wasn't declared explicitly so far.

Until miglayout-swing is used across the SciJava software stack, we need to exclude miglayout from other dependencies.

* The exclusions can be removed once https://github.com/scijava/scijava-ui-awt/pull/1, https://github.com/scijava/scijava-ui-swing/pull/46, https://github.com/scijava/script-editor/pull/40, https://github.com/scijava/scijava-search/pull/17, and https://github.com/imagej/imagej-ui-swing/pull/84 are all merged and released.
* The version pinning can be removed once we have a `pom-scijava` release managing this version (see https://github.com/scijava/pom-scijava/pull/97).