### PR TITLE
Add Java and TensorFlow requirements to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,26 @@ mvn -Pexec
 This requires [Maven](https://maven.apache.org/install.html).  Typically `brew
 install maven` on OS X, `apt-get install maven` on Ubuntu, or [detailed
 instructions](https://maven.apache.org/install.html) otherwise.
+
+## Issues when building from source
+This project currently requires JDK 8.
+You can check your Java version with:
+
+```sh
+java --version
+```
+
+For compatibility,
+it is also recommended to run with TensorFlow versions 1.14 or 1.15.
+
+If a native TensorFlow library fails to load,
+a crash marker file is created at `lib/linux64/.crashed`.
+
+If you fix the issue
+(e.g. by changing the native TF library or switching Java versions),
+delete the `.crashed` file, then run
+
+```sh
+mvn clean
+mvn -Pexec
+```


### PR DESCRIPTION
Added a new section to the README file describing fixes for issues I ran into when installing from source for the first time: JDK 8, TF 1.14 or 1.15 (recommended on image.sc) and the `.crashed` file.

Hopefully this saves future new contributors some consternation.