### PR TITLE
Removed the URLClassLoader for ClassGraph to check for native gpu.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,7 @@ Wisconsin-Madison and Google, Inc.</license.copyrightOwners>
 		<releaseProfiles>sign,deploy-to-scijava</releaseProfiles>
 
 		<imagej-updater.version>2.0.0</imagej-updater.version>
+		<classgraph.version>4.8.172</classgraph.version>
 	</properties>
 
 	<repositories>
@@ -183,6 +184,12 @@ Wisconsin-Madison and Google, Inc.</license.copyrightOwners>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-compress</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>io.github.classgraph</groupId>
+			<artifactId>classgraph</artifactId>
+			<version>${classgraph.version}</version>
+		</dependency>
+
 
 		<!-- Test dependencies -->
 		<dependency>

--- a/src/main/java/net/imagej/tensorflow/util/TensorFlowUtil.java
+++ b/src/main/java/net/imagej/tensorflow/util/TensorFlowUtil.java
@@ -30,6 +30,7 @@
 
 package net.imagej.tensorflow.util;
 
+import io.github.classgraph.ClassGraph;
 import net.imagej.tensorflow.TensorFlowVersion;
 import net.imagej.updater.util.Platforms;
 import org.scijava.log.Logger;
@@ -75,9 +76,12 @@ public final class TensorFlowUtil {
 		if(matcher.find()) {
 			// guess GPU support by looking for tensorflow_jni_gpu in the class path
 			boolean supportsGPU = false;
-			ClassLoader cl = ClassLoader.getSystemClassLoader();
-			for(URL url: ((URLClassLoader)cl).getURLs()){
-				if(url.getFile().contains("libtensorflow_jni_gpu")) {
+			ClassGraph cg = new ClassGraph();
+			String cp = cg.getClasspath();
+			String[] jars = cp.split(File.pathSeparator);
+
+			for(String j: jars){
+				if(j.contains("libtensorflow_jni_gpu")) {
 					supportsGPU = true;
 					break;
 				}


### PR DESCRIPTION
This is the same fix used for the scripting-java. Instead of using URLClassLoader, It uses ClassGraph to get the jar files. The jar files are checked to see if there is a gpu present.

